### PR TITLE
New: Support HTML reports

### DIFF
--- a/src/lib/formatters/html-report/html-report.ts
+++ b/src/lib/formatters/html-report/html-report.ts
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview The most basic formatter, it just stringifyes whatever object
+ * is passed to it.
+ */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as util from 'util';
+
+import * as _ from 'lodash';
+import * as Handlebars from 'handlebars';
+
+import { debug as d } from '../../utils/debug';
+import * as logger from '../../utils/logging';
+import { IFormatter, IProblem, Severity } from '../../types'; // eslint-disable-line no-unused-vars
+
+const debug = d(__filename);
+
+type Issues = {
+    issues: Array<IProblem>,
+    ruleId: string
+};
+
+type ResourceProblemData = { // eslint-disable-line no-unused-vars
+    resource: string,
+    totalErrors: number,
+    totalWarnings: number,
+    ruleIds: Array<Issues>
+};
+
+// Convert object to an key-value pair array.
+const transformToArray = (obj: { [key: string]: any }): Array<Issues> => {
+    return _.map(obj, (value, key) => {
+        return {
+            issues: value,
+            ruleId: key
+        };
+    });
+};
+
+const generateTimeStamp = (): string => {
+    const t = new Date();
+
+    return `${t.getMonth()}-${t.getDate()}-${t.getFullYear()}_${t.getHours()}-${t.getMinutes()}-${t.getSeconds()}`;
+};
+
+const writeReport = async (reportFolderPath: string, content: string): Promise<void> => {
+    try {
+        await util.promisify(fs.stat)(reportFolderPath);
+    } catch (err) {
+        // File path doesn't exist, create a new folder.
+        await util.promisify(fs.mkdir)(reportFolderPath);
+
+        logger.log(`New folder was created to save the reports: ${reportFolderPath}`);
+    }
+
+    const timeStamp: string = generateTimeStamp();
+
+    await util.promisify(fs.writeFile)(path.join(reportFolderPath, `${timeStamp}.html`), content, 'utf8');
+
+    logger.log(`The html report was generated and saved as ${timeStamp}.html`);
+};
+
+Handlebars.registerHelper('getSeverityClass', (severity: number): string => {
+    return Severity.error === severity ? 'error' : 'warning';
+});
+
+const processData = (resources: _.Dictionary<Array<IProblem>>): Array<ResourceProblemData> => {
+    debug('Processing data');
+
+    return _.map(resources, (issues: Array<IProblem>, resource: string): ResourceProblemData => {
+        let totalErrors: number = 0;
+        let totalWarnings: number = 0;
+
+        _.forEach(issues, (issue: IProblem): void => {
+            if (issue.location && issue.location.column === -1 && issue.location.line === -1) {
+                issue.location = null;
+            }
+
+            if (issue.severity === Severity.error) {
+                totalErrors += 1;
+            } else {
+                totalWarnings += 1;
+            }
+        });
+
+        return {
+            resource,
+            // Convert to array to suit the use in Handlebars.
+            ruleIds: transformToArray(_.groupBy(issues, 'ruleId')),
+            totalErrors,
+            totalWarnings
+        };
+    });
+};
+
+// ------------------------------------------------------------------------------
+// Formatter
+// ------------------------------------------------------------------------------
+
+const formatter: IFormatter = {
+    /** Format the problems grouped by `resource` name and sorted by line and column number */
+    async format(messages: Array<IProblem>) {
+
+        debug('Formatting results');
+
+        const resources: _.Dictionary<Array<IProblem>> = _.groupBy(messages, 'resource');
+        const templatePath: string = path.join(__dirname, 'report.hbs');
+        const reportFolderPath: string = path.join(process.cwd(), 'reports');
+
+        let templateContent: string;
+
+        try {
+            debug('Reading template');
+            templateContent = await util.promisify(fs.readFile)(templatePath, 'utf8');
+        } catch (err) {
+            debug(`Error reading template: ${templatePath}`);
+            throw (err);
+        }
+
+        const template: HandlebarsTemplateDelegate<any> = Handlebars.compile(templateContent);
+        const html: string = template({ resources: processData(resources) });
+
+        try {
+            await writeReport(reportFolderPath, html);
+        } catch (err) {
+            debug('Error writing the html report', err);
+        }
+    }
+};
+
+export default formatter;

--- a/src/lib/formatters/html-report/report.hbs
+++ b/src/lib/formatters/html-report/report.hbs
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>Sonar Report</title>
+    <style>
+        body {
+            font: 14px Consolas, Courier, monospace;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        p {
+            margin: 0;
+            padding: 0;
+        }
+
+        .highlight {
+            color: #111;
+            font-weight: bold;
+        }
+
+        .container.error {
+            background-color: #f99;
+        }
+
+        .container.warning {
+            background-color: #ff6;
+        }
+
+        .step {
+            margin: 10px;
+        }
+
+        .step .text {
+            border-radius: 3px;
+            color: #666;
+            padding: 5px;
+            display: block;
+        }
+
+        .container {
+            background: #f8f8f8;
+            border-radius: 5px;
+            border: 1px solid #e8e8e8;
+            padding: 10px;
+            margin: 10px;
+        }
+    </style>
+</head>
+<meta charset="utf-8">
+
+<body>
+    {{#each resources}}
+    <div class="feature container">
+        <h3 class="title"><span class="highlight">Resource: </span>{{resource}}</h3>
+        <p>Total Errors: {{totalErrors}}; Total Warnings: {{totalWarnings}}</p>
+        {{#each ruleIds}}
+        <div class="element container">
+            <h3 class="title"><span class="highlight">Rule: </span>
+                <a href="https://sonarwhal.com/docs/user-guide/rules/{{ruleId}}.html">
+                        {{ruleId}}
+                    </a>
+            </h3>
+            {{#each issues}}
+            <div class="container {{getSeverityClass severity}}">
+                {{#if location}}
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:{{location.line}};
+                        col:{{location.column}}
+                        </span>
+                    </p>
+                </div>
+                {{/if}}
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        {{message}}
+                    </div>
+                </div>
+                {{#if sourceCode}}
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Source Code:</span>
+                        </span>
+                    </p>
+                    <div>
+                        {{sourceCode}}
+                    </div>
+                </div>
+                {{/if}}
+            </div>
+            {{/each}}
+        </div>
+        {{/each}}
+    </div>
+    {{/each}}
+</body>
+
+</html>

--- a/tests/lib/formatters/fixtures/html-report-multiple-problems.html
+++ b/tests/lib/formatters/fixtures/html-report-multiple-problems.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>Sonar Report</title>
+    <style>
+        body {
+            font: 14px Consolas, Courier, monospace;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        p {
+            margin: 0;
+            padding: 0;
+        }
+
+        .highlight {
+            color: #111;
+            font-weight: bold;
+        }
+
+        .container.error {
+            background-color: #f99;
+        }
+
+        .container.warning {
+            background-color: #ff6;
+        }
+
+        .step {
+            margin: 10px;
+        }
+
+        .step .text {
+            border-radius: 3px;
+            color: #666;
+            padding: 5px;
+            display: block;
+        }
+
+        .container {
+            background: #f8f8f8;
+            border-radius: 5px;
+            border: 1px solid #e8e8e8;
+            padding: 10px;
+            margin: 10px;
+        }
+    </style>
+</head>
+<meta charset="utf-8">
+
+<body>
+    <div class="feature container">
+        <h3 class="title"><span class="highlight">Resource: </span>http://myresource.com/</h3>
+        <p>Total Errors: 0; Total Warnings: 4</p>
+        <div class="element container">
+            <h3 class="title"><span class="highlight">Rule: </span>
+                <a href="https://sonarwhal.com/docs/user-guide/rules/random-rule.html">
+                        random-rule
+                    </a>
+            </h3>
+            <div class="container warning">
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:1;
+                        col:10
+                        </span>
+                    </p>
+                </div>
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        This is a problem in line 1 column 10
+                    </div>
+                </div>
+            </div>
+            <div class="container warning">
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:10;
+                        col:1
+                        </span>
+                    </p>
+                </div>
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        This is a problem in line 10
+                    </div>
+                </div>
+            </div>
+            <div class="container warning">
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:5;
+                        col:1
+                        </span>
+                    </p>
+                </div>
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        This is a problem in line 5
+                    </div>
+                </div>
+            </div>
+            <div class="container warning">
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:1;
+                        col:1
+                        </span>
+                    </p>
+                </div>
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        This is a problem in line 1 column 1
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/tests/lib/formatters/fixtures/html-report-multiple-resources.html
+++ b/tests/lib/formatters/fixtures/html-report-multiple-resources.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>Sonar Report</title>
+    <style>
+        body {
+            font: 14px Consolas, Courier, monospace;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        p {
+            margin: 0;
+            padding: 0;
+        }
+
+        .highlight {
+            color: #111;
+            font-weight: bold;
+        }
+
+        .container.error {
+            background-color: #f99;
+        }
+
+        .container.warning {
+            background-color: #ff6;
+        }
+
+        .step {
+            margin: 10px;
+        }
+
+        .step .text {
+            border-radius: 3px;
+            color: #666;
+            padding: 5px;
+            display: block;
+        }
+
+        .container {
+            background: #f8f8f8;
+            border-radius: 5px;
+            border: 1px solid #e8e8e8;
+            padding: 10px;
+            margin: 10px;
+        }
+    </style>
+</head>
+<meta charset="utf-8">
+
+<body>
+    <div class="feature container">
+        <h3 class="title"><span class="highlight">Resource: </span>http://myresource.com/</h3>
+        <p>Total Errors: 0; Total Warnings: 4</p>
+        <div class="element container">
+            <h3 class="title"><span class="highlight">Rule: </span>
+                <a href="https://sonarwhal.com/docs/user-guide/rules/random-rule.html">
+                        random-rule
+                    </a>
+            </h3>
+            <div class="container warning">
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:1;
+                        col:10
+                        </span>
+                    </p>
+                </div>
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        This is a problem in line 1 column 10
+                    </div>
+                </div>
+            </div>
+            <div class="container warning">
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:10;
+                        col:1
+                        </span>
+                    </p>
+                </div>
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        This is a problem in line 10
+                    </div>
+                </div>
+            </div>
+            <div class="container warning">
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:5;
+                        col:1
+                        </span>
+                    </p>
+                </div>
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        This is a problem in line 5
+                    </div>
+                </div>
+            </div>
+            <div class="container warning">
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">Location</span>: line:1;
+                        col:1
+                        </span>
+                    </p>
+                </div>
+                <div class="step">
+                    <p>
+                        <span class="text">
+                                <span class="keyword highlight">message:</span>
+                        </span>
+                    </p>
+                    <div>
+                        This is a problem in line 1 column 1
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/tests/lib/formatters/fixtures/html-report-no-problem.html
+++ b/tests/lib/formatters/fixtures/html-report-no-problem.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>Sonar Report</title>
+    <style>
+        body {
+            font: 14px Consolas, Courier, monospace;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        p {
+            margin: 0;
+            padding: 0;
+        }
+
+        .highlight {
+            color: #111;
+            font-weight: bold;
+        }
+
+        .container.error {
+            background-color: #f99;
+        }
+
+        .container.warning {
+            background-color: #ff6;
+        }
+
+        .step {
+            margin: 10px;
+        }
+
+        .step .text {
+            border-radius: 3px;
+            color: #666;
+            padding: 5px;
+            display: block;
+        }
+
+        .container {
+            background: #f8f8f8;
+            border-radius: 5px;
+            border: 1px solid #e8e8e8;
+            padding: 10px;
+            margin: 10px;
+        }
+    </style>
+</head>
+<meta charset="utf-8">
+
+<body>
+</body>
+
+</html>

--- a/tests/lib/formatters/html-report.ts
+++ b/tests/lib/formatters/html-report.ts
@@ -1,0 +1,125 @@
+import test from 'ava';
+import * as sinon from 'sinon';
+import * as proxyquire from 'proxyquire';
+import * as path from 'path';
+import { readFileAsync } from '../../../src/lib/utils/misc';
+
+const templatePath = path.join(__dirname, '../../../src/lib/formatters/html-report/report.hbs');
+const noProblemHtmlPath = path.join(__dirname, 'fixtures/html-report-no-problem.html');
+const multipleProblemsPath = path.join(__dirname, 'fixtures/html-report-multiple-problems.html');
+const multipleResourcesPath = path.join(__dirname, 'fixtures/html-report-multiple-resources.html');
+let template;
+
+const stubFsObject = {
+    mkdir() { },
+    readFile() { },
+    stat() { },
+    writeFile() { }
+};
+
+const stubPromisifiedMethodObject = {
+    mkdirAsync() { },
+    readFileAsync() { },
+    statAsync() { },
+    writeFileAsync() { }
+};
+
+const stubUtilObject = {
+    promisify(method) {
+        return stubPromisifiedMethodObject[`${method.name}Async`];
+    }
+};
+
+proxyquire('../../../src/lib/formatters/html-report/html-report', {
+    fs: stubFsObject,
+    util: stubUtilObject
+});
+
+import htmlReport from '../../../src/lib/formatters/html-report/html-report';
+import * as problems from './fixtures/list-of-problems';
+
+test.beforeEach(async (t) => {
+    template = template || await readFileAsync(templatePath);
+
+    sinon.stub(stubPromisifiedMethodObject, 'writeFileAsync').resolves();
+    sinon.stub(stubPromisifiedMethodObject, 'readFileAsync').resolves(template);
+    sinon.stub(stubPromisifiedMethodObject, 'mkdirAsync').resolves();
+    sinon.spy(stubUtilObject, 'promisify');
+
+    t.context.promisify = stubUtilObject.promisify;
+    t.context.writeFileAsync = stubPromisifiedMethodObject.writeFileAsync;
+    t.context.readFileAsync = stubPromisifiedMethodObject.readFileAsync;
+    t.context.mkdirAsync = stubPromisifiedMethodObject.mkdirAsync;
+});
+
+test.afterEach.always((t) => {
+    t.context.promisify.restore();
+    t.context.writeFileAsync.restore();
+    t.context.readFileAsync.restore();
+    t.context.mkdirAsync.restore();
+});
+
+test.serial(`There is no problem`, async (t) => {
+    const writeFileAsyncFn = t.context.writeFileAsync;
+    const noProblemHtml = await readFileAsync(noProblemHtmlPath);
+
+    sinon.stub(stubPromisifiedMethodObject, 'statAsync').resolves();
+    t.context.statAsync = stubPromisifiedMethodObject.statAsync;
+
+    await htmlReport.format(problems.noproblems);
+
+    t.is(t.context.statAsync.callCount, 1);
+    t.is(t.context.mkdirAsync.callCount, 0);
+    t.is(t.context.readFileAsync.callCount, 1);
+    t.is(writeFileAsyncFn.callCount, 1);
+    t.is(writeFileAsyncFn.args[0][1], noProblemHtml);
+
+    t.context.statAsync.restore();
+});
+
+test.serial('Multiple problems', async (t) => {
+    const writeFileAsyncFn = t.context.writeFileAsync;
+    const multipleProblemHtml = await readFileAsync(multipleProblemsPath);
+
+    sinon.stub(stubPromisifiedMethodObject, 'statAsync').resolves();
+    t.context.statAsync = stubPromisifiedMethodObject.statAsync;
+
+    await htmlReport.format(problems.multipleproblems);
+
+    t.is(t.context.statAsync.callCount, 1);
+    t.is(t.context.mkdirAsync.callCount, 0);
+    t.is(t.context.readFileAsync.callCount, 1);
+    t.is(writeFileAsyncFn.callCount, 1);
+    t.is(writeFileAsyncFn.args[0][1], multipleProblemHtml);
+
+    t.context.statAsync.restore();
+});
+
+test.serial('Multiple resources', async (t) => {
+    const writeFileAsyncFn = t.context.writeFileAsync;
+    const multipleResourcesHtml = await readFileAsync(multipleResourcesPath);
+
+    sinon.stub(stubPromisifiedMethodObject, 'statAsync').resolves();
+    t.context.statAsync = stubPromisifiedMethodObject.statAsync;
+
+    await htmlReport.format(problems.multipleproblems);
+
+    t.is(t.context.statAsync.callCount, 1);
+    t.is(t.context.mkdirAsync.callCount, 0);
+    t.is(t.context.readFileAsync.callCount, 1);
+    t.is(writeFileAsyncFn.callCount, 1);
+    t.is(writeFileAsyncFn.args[0][1], multipleResourcesHtml);
+
+    t.context.statAsync.restore();
+});
+
+test.serial(`Report folder doesn't exist`, async (t) => {
+    sinon.stub(stubPromisifiedMethodObject, 'statAsync').rejects();
+    t.context.statAsync = stubPromisifiedMethodObject.statAsync;
+
+    await htmlReport.format(problems.multipleproblems);
+
+    t.is(t.context.mkdirAsync.callCount, 1);
+
+    t.context.statAsync.restore();
+});


### PR DESCRIPTION
This is a starter for supporting the html reports. The current layout of the report is very simple which requires further design if the look is a critical concern.  The structure is shown as follows:

* Resource1: ...
  A short summary (Total Errors: ... ; Total Warnings: ...)
  * Rule1: link to the rule
      * Problem1 (location, message, source code)
      * Problem 2 
  * Rule2: link to the rule
     * Problem1
      * Problem 2 
* Resource 2: ...
...

Problems under the same rule from the same resource are grouped together, and the severity level of each rule is indicated by the background color. The page could run pretty long, but we can consider using collapsible panels like [this](http://htmlpreview.github.io/?https://github.com/gkushang/cucumber-html-reporter/blob/develop/samples/html_reports/cucumber_report_bootstrap.html) to make it easier for users to navigate through `resource`s and `rule`s.

Each time a new report is generated, the timestamp is used to name the file and save it in the `report` folder.  

Please let me know if you think any other information should be included in the html reports. @sonarwhal/contributors 

![htmll-report](https://user-images.githubusercontent.com/20218531/29047824-7d0bc39a-7b82-11e7-9136-c9b9bd4dc045.PNG)


Fix #284 