### PR TITLE
New: Added Chrome Traces to cdp connector

### DIFF
--- a/src/lib/connectors/shared/remote-debugging-connector.ts
+++ b/src/lib/connectors/shared/remote-debugging-connector.ts
@@ -521,7 +521,7 @@ export class Connector implements IConnector {
     /** Initiates all the process */
     private onLoadEventFired(callback: Function): Function {
         return () => {
-            const { DOM } = this._client;
+            const { DOM, Tracing } = this._client;
             const event: IEvent = { resource: this._finalHref };
 
             setTimeout(async () => {
@@ -548,6 +548,15 @@ export class Connector implements IConnector {
                         await this.getFavicon((await this._dom.querySelectorAll('link[rel~="icon"]'))[0]);
                     }
 
+                    await new Promise((resolve) => {
+                        Tracing.tracingComplete(() => {
+                            this._server.emitAsync('tracing::end', event);
+                            resolve();
+
+                        });
+                        debug(`Ending Collecting Chrome traces`);
+                        Tracing.end();
+                    });
                     await this._server.emitAsync('scan::end', event);
 
                     // We are going to wait until all the requests are finished or this._options.maxLoadWaitTime seconds before finish
@@ -597,7 +606,7 @@ export class Connector implements IConnector {
             }
 
             this._client = client;
-            const { Page, Security } = client;
+            const { Page, Security, Tracing } = client;
 
             // Bypassing the "Your connection is not private"
             // certificate error when using self signed certificate
@@ -625,6 +634,11 @@ export class Connector implements IConnector {
 
             try {
                 await this.configureAndEnableCDP();
+                Tracing.dataCollected((data) => {
+                    this._server.emitAsync('tracing::data', { data, resource: event.resource });
+                });
+                debug(`Starting collecting Chrome Traces`);
+                await Tracing.start();
 
                 await Page.navigate({ url: target.href });
             } catch (e) {


### PR DESCRIPTION
Chrome Traces has much more information about performance and
rules can use the new events - tracing::data and tracing::end
for trace information.

This information can be used for new rules like firstPaint,
total time taken to parseHTML, long frames, rendering, etc.