### PR TITLE
Docs: Fix PR Guidelines link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,4 +12,4 @@ request that you read over our code of conduct before contributing.
 ## Contributing Code
 
 Please sign our [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
-and read the [Pull Request Guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests).
+and read the [Pull Request Guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/).


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

(Hi, this is the tiniest first PR possible, but hopefully I can make bigger contributions in future!)

Add a trailing "/" to the Pull Request Guidelines link. Without it, it redirects me [here](https://sonarwhal.com/dist/docs/contributor-guide/contributing/pull-requests/), which gives a 404.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
