### PR TITLE
Docs: Fix rule name in example in

### DIFF
--- a/docs/user-guide/rules/no-http-redirects.md
+++ b/docs/user-guide/rules/no-http-redirects.md
@@ -54,7 +54,7 @@ The following configuration will allow 3 redirects for resources and
 
 ```json
 {
-    "no-redirects": ["error", {
+    "no-http-redirects": ["error", {
         "max-resource-redirects": 3,
         "max-target-redirects": 1
     }]


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->

This pull request is just fixing the example of the documentation of the `no-http-redirects` rule. It was mistakenly named `no-redirects` in the example before.