### PR TITLE
Chore: Pass `options` to request method in utils

### DIFF
--- a/src/lib/utils/misc.ts
+++ b/src/lib/utils/misc.ts
@@ -142,11 +142,13 @@ const readFileAsync = async (filePath: string): Promise<string> => {
 };
 
 /** Request response in the json format from an endpoint */
-const requestJSONAsync = (uri: string) => {
-    return requestAsync({
+const requestJSONAsync = (uri: string, options: object) => {
+    const params = Object.assign({
         json: true,
         uri
-    });
+    }, options);
+
+    return requestAsync(params);
 };
 
 /** Convenience wrapper for asynchronously write a file. */


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
Allow passing `options` to utility method `requestJSONAsync`. Necessary for the rule that I'm working on.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
