### PR TITLE
Fix: Pass parsers to tests

### DIFF
--- a/docs/contributor-guide/rules/index.md
+++ b/docs/contributor-guide/rules/index.md
@@ -544,8 +544,16 @@ const rule: IRuleBuilder = {
 };
 ```
 
+And when writing tests, you need to specify the parsers that you need:
+
+```ts
+ruleRunner.testRule(ruleName, tests, {
+    parsers: ['javascript']
+});
+```
+
 <!-- Link labels: -->
 
 [browserconfiguration]: ../../user-guide/index.md#browserconfiguration
 [json schema]: http://json-schema.org/
-[parser]: ../../user-guide/concepts/parser.md
+[parsers]: ../../user-guide/concepts/parser.md

--- a/tests/helpers/rule-runner.ts
+++ b/tests/helpers/rule-runner.ts
@@ -36,6 +36,7 @@ export const testRule = (ruleId: string, ruleTests: Array<IRuleTest>, configs: {
                 name: connector,
                 options: {}
             },
+            parsers: opts && opts.parsers || [],
             rules
         };
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)
1. Pass parsers to tests so that `parse::javascript` and other parsing events are emitted in tests.
2. Fixed a bug in documentation.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
