### PR TITLE
New: Add `element` info to `traverse` events

### DIFF
--- a/src/lib/connectors/debugging-protocol-common/debugging-protocol-connector.ts
+++ b/src/lib/connectors/debugging-protocol-common/debugging-protocol-connector.ts
@@ -602,13 +602,19 @@ export class Connector implements IConnector {
 
         for (const child of elementChildren) {
             debug('next children');
-            const traverseDown: ITraverseDown = { resource: this._finalHref };
+            const traverseDown: ITraverseDown = {
+                element,
+                resource: this._finalHref
+            };
 
             await this._server.emitAsync(`traverse::down`, traverseDown);
             await this.traverseAndNotify(child);
         }
 
-        const traverseUp: ITraverseUp = { resource: this._finalHref };
+        const traverseUp: ITraverseUp = {
+            element,
+            resource: this._finalHref
+        };
 
         await this._server.emitAsync(`traverse::up`, traverseUp);
     }

--- a/src/lib/connectors/jsdom/jsdom.ts
+++ b/src/lib/connectors/jsdom/jsdom.ts
@@ -184,16 +184,22 @@ class JSDOMConnector implements IConnector {
             const child: HTMLElement = element.children[i] as HTMLElement;
 
             debug('next children');
-            const traverseDown: ITraverseDown = { resource: this._finalHref };
+            const traverseDown: ITraverseDown = {
+                element: new JSDOMAsyncHTMLElement(element),
+                resource: this._finalHref
+            };
 
-            await this._server.emitAsync(`traversing::down`, traverseDown);
+            await this._server.emitAsync(`traverse::down`, traverseDown);
             await this.traverseAndNotify(child);
 
         }
 
-        const traverseUp: ITraverseUp = { resource: this._finalHref };
+        const traverseUp: ITraverseUp = {
+            element: new JSDOMAsyncHTMLElement(element),
+            resource: this._finalHref
+        };
 
-        await this._server.emitAsync(`traversing::up`, traverseUp);
+        await this._server.emitAsync(`traverse::up`, traverseUp);
 
         return Promise.resolve();
     }

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -45,10 +45,16 @@ export interface ITraverseStart extends IEvent { }
 export interface ITraverseEnd extends IEvent { }
 
 /** The object emitted by a connector on `traverse::up` */
-export interface ITraverseUp extends IEvent { }
+export interface ITraverseUp extends IEvent {
+    /** The elemnent to traverse from */
+    element: IAsyncHTMLElement;
+}
 
 /** The object emitted by a connector on `traverse::down` */
-export interface ITraverseDown extends IEvent { }
+export interface ITraverseDown extends IEvent {
+    /** The elemnent to traverse from */
+    element: IAsyncHTMLElement;
+}
 
 /** The object emitted by a connector on `element::<element-type>`. */
 export interface IElementFound extends IEvent {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

The origin (element) of the `traverse::up` and `traverse::down` events is needed for some JSLL rules. It was included as part of this PR https://github.com/sonarwhal/sonarwhal/pull/690. But since we are moving all the JSLL rules to external rules, this change needs to be merged separately.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
