### PR TITLE
Fix: Add new patterns to `http-cache` revving

### DIFF
--- a/docs/user-guide/rules/http-cache.md
+++ b/docs/user-guide/rules/http-cache.md
@@ -35,18 +35,19 @@ validate that the page and resources have a good caching strategy:
     one based on query string parameters (see: [problems with
     proxys][revving files])
 
-The built-in regular expression for file revving are:
+The built-in regular expression for file revving is:
 
 ```regexp
-/\/(\w|-|_)+\.\w+\.\w+$/i,
-/\/(\w|-|_)+-\w+\.\w+$/i
+/\/(\w|-|_)+(\.|-|_)\w+\.\w+$/i
 ```
 
 This will match urls like the following:
 
 ```text
 https://example.com/assets/script.12345.js
-https://example.com/assets/styles-12345.css
+https://example.com/assets/script-2.12345.js
+https://example.com/assets/script_2-12345.js
+https://example.com/assets/icon_meca_1473335663.svg
 ```
 
 ## Can the rule be configured?

--- a/src/lib/rules/http-cache/http-cache.ts
+++ b/src/lib/rules/http-cache/http-cache.ts
@@ -63,9 +63,11 @@ const rule: IRuleBuilder = {
              * - https://example.com/assets/script.12345.js
              * - https://example.com/assets/script-2.12345.js
              * - https://example.com/assets/script_2-12345.js
+             * - https://example.com/assets/icon_meca_1473335663.svg
+             *
+             * Live example: https://regex101.com/r/6VduJO/2/
              */
-            /\/(\w|-|_)+\.\w+\.\w+$/i,
-            /\/(\w|-|_)+-\w+\.\w+$/i
+            /\/(\w|-|_)+(\.|-|_)\w+\.\w+$/i
         ];
 
         /** The cache revving patterns to use for matching.*/
@@ -344,7 +346,7 @@ const rule: IRuleBuilder = {
             });
 
             if (!matches) {
-                const message: string = `No patterns for file revving match ${resource}`;
+                const message: string = `No configured patterns for cache busting match ${resource}. See docs to add a custom one.`;
 
                 await context.report(resource, element, message);
 

--- a/tests/lib/rules/http-cache/tests.ts
+++ b/tests/lib/rules/http-cache/tests.ts
@@ -213,7 +213,7 @@ const defaultTests: Array<IRuleTest> = [
     },
     {
         name: 'JS with long max-age, immutable and no file revving fails',
-        reports: [{ message: 'No patterns for file revving match http://localhost/script.js' }],
+        reports: [{ message: 'No configured patterns for cache busting match http://localhost/script.js. See docs to add a custom one.' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/script.js"></script>'),
             '/favicon.123.ico': {
@@ -241,8 +241,22 @@ const defaultTests: Array<IRuleTest> = [
         }
     },
     {
+        name: 'JS with long max-age, immutable and file revving with `_` passes',
+        serverConfig: {
+            '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/script_123.js"></script>'),
+            '/favicon_123.ico': {
+                content: '',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            },
+            '/script_123.js': {
+                content: 'var a = 10;',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            }
+        }
+    },
+    {
         name: 'JS with long max-age, immutable and parameter file revving fails',
-        reports: [{ message: 'No patterns for file revving match http://localhost/script.js?v=123' }],
+        reports: [{ message: 'No configured patterns for cache busting match http://localhost/script.js?v=123. See docs to add a custom one.' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/script.js?v=123"></script>'),
             '/favicon.123.ico': {
@@ -273,7 +287,7 @@ const defaultTests: Array<IRuleTest> = [
     },
     {
         name: 'CSS with long max-age, immutable and no file revving fails',
-        reports: [{ message: 'No patterns for file revving match http://localhost/styles.css' }],
+        reports: [{ message: 'No configured patterns for cache busting match http://localhost/styles.css. See docs to add a custom one.' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><link rel="stylesheet" href="styles.css">'),
             '/favicon.123.ico': {
@@ -302,7 +316,7 @@ const defaultTests: Array<IRuleTest> = [
     },
     {
         name: 'CSS with long max-age, immutable and parameter file revving fails',
-        reports: [{ message: 'No patterns for file revving match http://localhost/styles.css?v=123' }],
+        reports: [{ message: 'No configured patterns for cache busting match http://localhost/styles.css?v=123. See docs to add a custom one.' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><link rel="stylesheet" href="styles.css?v=123">'),
             '/favicon.123.ico': {
@@ -319,7 +333,7 @@ const defaultTests: Array<IRuleTest> = [
 const customRegexTests: Array<IRuleTest> = [
     {
         name: 'JS with long max-age, immutable and file revving fails custom regex',
-        reports: [{ message: 'No patterns for file revving match http://localhost/script.123.js' }],
+        reports: [{ message: 'No configured patterns for cache busting match http://localhost/script.123.js. See docs to add a custom one.' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/12345/favicon.ico"><script src="/script.123.js"></script>'),
             '/12345/favicon.ico': {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [X] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)

* Add `_` as another separator for file revving in `http-cache` rule
* Point to the docs when no pattern is found so users know it can be
  configured

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #741

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
