### PR TITLE
Make `summary` the default formatter choice

### DIFF
--- a/.sonarwhalrc
+++ b/.sonarwhalrc
@@ -5,7 +5,7 @@
             "waitFor": 1000
         }
     },
-    "formatters": "stylish",
+    "formatters": "summary",
     "parsers": [],
     "rulesTimeout": 120000,
     "rules": {

--- a/src/lib/cli/init.ts
+++ b/src/lib/cli/init.ts
@@ -74,10 +74,10 @@ export const initSonarwhalrc = async (options: CLIOptions): Promise<boolean> => 
         },
         {
             choices: formattersKeys,
+            default: defaultFormatter,
             message: 'What formatter do you want to use?',
             name: 'formatter',
-            type: 'list',
-            default: defaultFormatter
+            type: 'list'
         },
         {
             message: 'Do you want to use the recommended rules configuration?',

--- a/src/lib/cli/init.ts
+++ b/src/lib/cli/init.ts
@@ -21,6 +21,7 @@ import * as resourceLoader from '../utils/resource-loader';
 import { generateBrowserslistConfig } from './browserslist';
 
 const debug: debug.IDebugger = d(__filename);
+const defaultFormatter = 'summary';
 
 /** Initiates a wizard to gnerate a valid `.sonarwhalrc` file based on user responses. */
 export const initSonarwhalrc = async (options: CLIOptions): Promise<boolean> => {
@@ -47,7 +48,7 @@ export const initSonarwhalrc = async (options: CLIOptions): Promise<boolean> => 
             name: '',
             options: { waitFor: 1000 }
         },
-        formatters: ['stylish'],
+        formatters: [defaultFormatter],
         ignoredUrls: [],
         rules: {},
         rulesTimeout: 120000
@@ -75,7 +76,8 @@ export const initSonarwhalrc = async (options: CLIOptions): Promise<boolean> => 
             choices: formattersKeys,
             message: 'What formatter do you want to use?',
             name: 'formatter',
-            type: 'list'
+            type: 'list',
+            default: defaultFormatter
         },
         {
             message: 'Do you want to use the recommended rules configuration?',


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

As per #722, this changes the default formatter to `summary`, i.e. it makes `summary` the default selected choice when you initialise your `.sonarwhalrc`.

A couple of questions, please:

1. As mentioned [on Gitter](https://gitter.im/sonarwhal/Lobby?at=5a6601e9517037a212dbc376), I'm having some trouble running the tests, so it'd be good to double-check that I haven't made any fail?

1. I accidentally missed doing the `lint` before the first commit, so ended up with a 2nd commit to fix the ordering. Should I squash the commits together?

Thanks :)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
