### PR TITLE
Fix: Fix `<details>` tag

### DIFF
--- a/docs/user-guide/rules/http-compression.md
+++ b/docs/user-guide/rules/http-compression.md
@@ -518,6 +518,7 @@ Content-Type: image/svg+xml
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
+
 <details>
 <summary>How to configure Apache</summary>
 
@@ -793,6 +794,7 @@ Also note that:
   file in the root of the web site/app.
 
 </details>
+
 <!-- markdownlint-enable MD033 -->
 
 ## Can the rule be configured?


### PR DESCRIPTION
Fix sonarwhal/sonarwhal.com#364

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [ ] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

This is an issue within the `html` regex in the markdown parser `marked` (See: https://github.com/chjj/marked/issues/1032). An issue was opened. Adding blank lines between the comments and the HTML code temporarily fixed the rendering problem.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
