### PR TITLE
Breaking: Limit `X-Content-Type-Options` usage to scripts and stylesheets

### DIFF
--- a/tests/helpers/test-server.ts
+++ b/tests/helpers/test-server.ts
@@ -281,7 +281,6 @@ export class Server {
                 res.status(200);
                 res.setHeader('Content-Length', '0');
                 res.setHeader('Content-Type', 'image/x-icon');
-                res.setHeader('X-Content-Type-Options', 'nosniff');
                 res.end();
             });
         }

--- a/tests/lib/rules/x-content-type-options/tests.ts
+++ b/tests/lib/rules/x-content-type-options/tests.ts
@@ -7,69 +7,70 @@ import * as ruleRunner from '../../../helpers/rule-runner';
 
 // Error messages.
 
-const noHeaderMessage = `'x-content-type-options' header was not specified`;
+const noHeaderMessage = `'x-content-type-options' header is not specified`;
+const unneededHeaderMessage = `'x-content-type-options' header is not needed`;
 const generateInvalidValueMessage = (value: string = '') => {
     return `'x-content-type-options' header value (${value}) is invalid`;
 };
 
 // Page data.
 
-const generateHTMLPageData = (content: string) => {
-    return {
-        content,
-        headers: { 'X-Content-Type-Options': 'nosniff' }
-    };
-};
-
-const htmlPageWithScriptData = generateHTMLPageData(generateHTMLPage(undefined, '<script src="test.js"></script>'));
-const htmlPageWithManifestData = generateHTMLPageData(generateHTMLPage('<link rel="manifest" href="test.webmanifest">'));
+const htmlPageWithScript = generateHTMLPage(undefined, '<script src="test.js"></script>');
+const htmlPageWithStylesheet = generateHTMLPage('<link rel="stylesheet" href="test.css">');
+const htmlPageWithManifest = generateHTMLPage('<link rel="manifest" href="test.webmanifest">');
 
 // Tests.
 
 const tests: Array<IRuleTest> = [
     {
         name: `HTML page is served without 'X-Content-Type-Options' header`,
-        reports: [{ message: noHeaderMessage }],
         serverConfig: { '/': '' }
     },
     {
         name: `Manifest is served without 'X-Content-Type-Options' header`,
-        reports: [{ message: noHeaderMessage }],
         serverConfig: {
-            '/': htmlPageWithManifestData,
+            '/': htmlPageWithManifest,
             '/test.webmanifest': ''
         }
     },
     {
-        name: `Resource is served without 'X-Content-Type-Options' header`,
+        name: `Script is served without 'X-Content-Type-Options' header`,
         reports: [{ message: noHeaderMessage }],
         serverConfig: {
-            '/': htmlPageWithScriptData,
+            '/': htmlPageWithScript,
             '/test.js': ''
         }
     },
     {
-        name: `Resource is specified as a data URI`,
-        serverConfig: { '/': generateHTMLPageData(generateHTMLPage(undefined, '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==">')) }
-    },
-    {
-        name: `HTML page is served with 'X-Content-Type-Options' header with invalid value`,
-        reports: [{ message: generateInvalidValueMessage('no-sniff') }],
-        serverConfig: { '/': { headers: { 'X-Content-Type-Options': 'no-sniff' } } }
-    },
-    {
-        name: `Manifest is served with 'X-Content-Type-Options' header with invalid value`,
-        reports: [{ message: generateInvalidValueMessage() }],
+        name: `Stylesheet is served without 'X-Content-Type-Options' header`,
+        reports: [{ message: noHeaderMessage }],
         serverConfig: {
-            '/': htmlPageWithManifestData,
-            '/test.webmanifest': { headers: { 'X-Content-Type-Options': '' } }
+            '/': htmlPageWithStylesheet,
+            '/test.css': ''
         }
     },
     {
-        name: `Resource is served with 'X-Content-Type-Options' header with invalid value`,
+        name: `Resource is specified as a data URI`,
+        serverConfig: { '/': generateHTMLPage(undefined, '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==">') }
+    },
+    {
+        name: `HTML page is served with the 'X-Content-Type-Options' header`,
+        reports: [{ message: unneededHeaderMessage }],
+        serverConfig: { '/': { headers: { 'X-Content-Type-Options': 'nosniff' } } }
+    },
+    {
+        name: `Manifest is served without 'X-Content-Type-Options' header`,
+        reports: [{ message: unneededHeaderMessage }],
+        serverConfig: {
+            '/': htmlPageWithManifest,
+            '/test.webmanifest': { headers: { 'X-Content-Type-Options': 'invalid' } }
+        }
+    },
+    {
+        name: `Script is served with 'X-Content-Type-Options' header with invalid value`,
         reports: [{ message: generateInvalidValueMessage('invalid') }],
         serverConfig: {
-            '/': htmlPageWithScriptData,
+            '/': htmlPageWithScript,
             '/test.js': { headers: { 'X-Content-Type-Options': 'invalid' } }
         }
     }


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Change `x-content-type-options` rule so that it limits the usage of the `X-Content-Type-Options` header to scripts and stylesheets as [modern browsers actually only respect the header for those
types of resources](https://fetch.spec.whatwg.org/#x-content-type-options-header).

Also, sending the header for resources such as images, [creates problems](https://github.com/whatwg/fetch/issues/395) in some older browsers.

Fix #767

