### PR TITLE
Docs: Fix typo in `options.ts`

### DIFF
--- a/src/lib/cli/options.ts
+++ b/src/lib/cli/options.ts
@@ -95,7 +95,7 @@ export const options = optionator({
         },
         {
             alias: 'w',
-            description: 'Activate a watcher for the connector (if sopported)',
+            description: 'Activate a watcher for the connector (if supported)',
             option: 'watch',
             type: 'Boolean'
         }


### PR DESCRIPTION
- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

Fix a typo in CLI description
