### PR TITLE
Docs: Update format so `<details>` render on site

### DIFF
--- a/docs/user-guide/rules/content-type.md
+++ b/docs/user-guide/rules/content-type.md
@@ -109,9 +109,7 @@ Content-Type: text/javascript; charset=utf-8
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
-
-<details>
-<summary>How to configure Apache</summary>
+<details><summary>How to configure Apache</summary>
 
 By default Apache [maps certain filename extensions to specific media
 types][mime.types file], but depending on the Apache version that is
@@ -268,9 +266,7 @@ Note that:
   file in the root of the web site/app.
 
 </details>
-
-<details>
-<summary>How to configure IIS</summary>
+<details><summary>How to configure IIS</summary>
 
 By default IIS [maps certain filename extensions to specific media
 types][mime.types iis], but depending on the IIS version that is

--- a/docs/user-guide/rules/highest-available-document-mode.md
+++ b/docs/user-guide/rules/highest-available-document-mode.md
@@ -219,9 +219,7 @@ X-UA-Compatible: ie=edge
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
-
-<details>
-<summary>How to configure Apache</summary>
+<details><summary>How to configure Apache</summary>
 
 Apache can be configured to add or remove the `X-UA-Compatible`
 header using the [`Header` directive][header directive].
@@ -282,9 +280,7 @@ Note that:
   file in the root of the web site/app.
 
 </details>
-
-<details>
-<summary>How to configure IIS</summary>
+<details><summary>How to configure IIS</summary>
 
 ### Adding the `X-UA-Compatible` header on IIS
 
@@ -372,6 +368,7 @@ not sending the HTTP response header.
 <!-- Apache links -->
 
 [apache directory]: https://httpd.apache.org/docs/current/mod/core.html#directory
+[header directive]: https://httpd.apache.org/docs/current/mod/mod_headers.html#header
 [how to enable apache modules]: https://github.com/h5bp/server-configs-apache/wiki/How-to-enable-Apache-modules
 [htaccess is slow]: https://httpd.apache.org/docs/current/howto/htaccess.html#when
 [main apache conf file]: https://httpd.apache.org/docs/current/configuring.html#main

--- a/docs/user-guide/rules/http-cache.md
+++ b/docs/user-guide/rules/http-cache.md
@@ -153,9 +153,7 @@ Cache-Control: no-cache
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
-
-<details>
-<summary>How to configure Apache</summary>
+<details><summary>How to configure Apache</summary>
 
 Enabling Apache to automatically add the `Cache-Control` header
 (as well as the equivalent `Expires` header) can be done using the
@@ -278,9 +276,7 @@ Also note that:
   file in the root of the web site/app.
 
 </details>
-
-<details>
-<summary>How to configure IIS</summary>
+<details><summary>How to configure IIS</summary>
 
 You can enable the `Cache-Control` and/or `Expire` headers on IIS using
 the [`<clientCache> element under <staticContent>`][clientcache iis].

--- a/docs/user-guide/rules/http-compression.md
+++ b/docs/user-guide/rules/http-compression.md
@@ -518,9 +518,7 @@ Content-Type: image/svg+xml
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
-
-<details>
-<summary>How to configure Apache</summary>
+<details><summary>How to configure Apache</summary>
 
 Apache can be configured to conditionally (based on media type)
 compress resources using gzip as well as send the appropriate
@@ -789,9 +787,7 @@ Also note that:
   file in the root of the web site/app.
 
 </details>
-
-<details>
-<summary>How to configure IIS</summary>
+<details><summary>How to configure IIS</summary>
 
 IIS 7+ can be configured to compress responses (static or dynamic) via
 the [`<urlCompression> element`][urlcompression].

--- a/docs/user-guide/rules/no-disallowed-headers.md
+++ b/docs/user-guide/rules/no-disallowed-headers.md
@@ -81,9 +81,7 @@ HTTP/... 200 OK
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
-
-<details>
-<summary>How to configure Apache</summary>
+<details><summary>How to configure Apache</summary>
 
 If the headers are sent, in most cases, to make Apache stop sending
 them requires just removing the configurations that tells Apache to
@@ -142,9 +140,7 @@ Note that:
   `.htaccess` file in the root of the web site/app.
 
 </details>
-
-<details>
-<summary>How to configure IIS</summary>
+<details><summary>How to configure IIS</summary>
 
 To add or remove headers on IIS, you can use the
 [`<customHeader> element`][customheader] and `<remove>/<add>`

--- a/docs/user-guide/rules/no-html-only-headers.md
+++ b/docs/user-guide/rules/no-html-only-headers.md
@@ -85,9 +85,7 @@ X-XSS-Protection: 1; mode=block
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
-
-<details>
-<summary>How to configure Apache</summary>
+<details><summary>How to configure Apache</summary>
 
 Apache can be configured to remove headers using the [`Header`
 directive][header directive].
@@ -129,9 +127,7 @@ Note that:
   file in the root of the web site/app.
 
 </details>
-
-<details>
-<summary>How to configure IIS</summary>
+<details><summary>How to configure IIS</summary>
 
 If your application is adding the headers unconditionally to all
 responses and you cannot modify it, the solution is to create

--- a/docs/user-guide/rules/strict-transport-security.md
+++ b/docs/user-guide/rules/strict-transport-security.md
@@ -118,9 +118,7 @@ HTTP/... 200 OK
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
-
-<details>
-<summary>How to configure Apache</summary>
+<details><summary>How to configure Apache</summary>
 
 Apache can be configured to serve resources with the
 `Strict-Transport-Security` header with a specific value
@@ -149,9 +147,7 @@ Note that:
   file in the root of the web site/app.
 
 </details>
-
-<details>
-<summary>How to configure IIS</summary>
+<details><summary>How to configure IIS</summary>
 
 IIS can be configured to serve resources with the `Strict-Transport-Security`
 header with a specific value using the [`<customHeader> element`][customHeader].

--- a/docs/user-guide/rules/x-content-type-options.md
+++ b/docs/user-guide/rules/x-content-type-options.md
@@ -82,9 +82,7 @@ X-Content-Type-Options: nosniff
 ## How to configure the server to pass this rule
 
 <!-- markdownlint-disable MD033 -->
-
-<details>
-<summary>How to configure Apache</summary>
+<details><summary>How to configure Apache</summary>
 
 Presuming the script files use the `.js` or `.mjs` extension, and
 the stylesheets `.css`, Apache can be configured to serve the with
@@ -116,9 +114,7 @@ Note that:
   file in the root of the web site/app.
 
 </details>
-
-<details>
-<summary>How to configure IIS</summary>
+<details><summary>How to configure IIS</summary>
 
 Presuming the script files are sent with the `Content-Type` header set
 to `text/javascript` and styleshees to `text/css` you can use


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [X] Added/Updated related documentation.

## Short description of the change(s)

For the markdown processor to recognize things correctly the `<details>`
and `<summary>` elements need to be in the same line. Also, they cannot
have any empty lines above or otherwise they will be wrapped on a `<p>`
and break the output.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: https://github.com/sonarwhal/sonarwhal.com/issues/367

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
