### PR TITLE
Fix: Fix `parse::javascript` emit timing

### DIFF
--- a/src/lib/parsers/javascript/javascript.ts
+++ b/src/lib/parsers/javascript/javascript.ts
@@ -34,7 +34,7 @@ export default class JavascriptParser extends Parser {
         await this.sonarwhal.emitAsync('parse::javascript', scriptData);
     }
 
-    private parseJavascript(fetchEnd: IFetchEnd) {
+    private async parseJavascript(fetchEnd: IFetchEnd) {
         if (fetchEnd.response.mediaType !== 'text/javascript') {
             return;
         }
@@ -42,7 +42,7 @@ export default class JavascriptParser extends Parser {
         const code = fetchEnd.response.body.content;
         const resource = fetchEnd.resource;
 
-        this.emitScript(code, resource);
+        await this.emitScript(code, resource);
     }
 
     private hasSrcAttribute(element: IAsyncHTMLElement) {
@@ -85,6 +85,6 @@ export default class JavascriptParser extends Parser {
         const code = this.getScriptContent(await element.outerHTML());
         const resource: string = 'Internal javascript';
 
-        this.emitScript(code, resource);
+        await this.emitScript(code, resource);
     }
 }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

This solves the issue mentioned in https://github.com/Microsoft/sonarwhal-rules-microsoft/pull/6#discussion_r163625035, which makes sure the handler that subscribes to `parse::javascript` of the internal script finishes before the `element::body` handler.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
