### PR TITLE
Fix: Fix failed amp validator test

### DIFF
--- a/tests/lib/rules/amp-validator/tests.ts
+++ b/tests/lib/rules/amp-validator/tests.ts
@@ -19,10 +19,7 @@ const defaultTests: Array<IRuleTest> = [
     {
         name: 'Invalid AMP HTML fails',
         serverConfig: invalidAMPHTML,
-        reports: [
-            { message: `The mandatory attribute '⚡' is missing in tag 'html ⚡ for top-level html'. (https://www.ampproject.org/docs/reference/spec#required-markup)` },
-            { message: `The mandatory tag 'html ⚡ for top-level html' is missing or incorrect. (https://www.ampproject.org/docs/reference/spec#required-markup)` }
-        ]
+        reports: [{ message: `The mandatory attribute '⚡' is missing in tag 'html ⚡ for top-level html'. (https://www.ampproject.org/docs/reference/spec#required-markup)` }]
     },
     {
         name: 'Deprecated AMP attribute fails',


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)

The failed test is caused by a redundant expected message, I can't find out why it passed before. According to scan result in https://validator.ampproject.org/, there should be only one error message in the `invalid AMP HTML` case.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
