### PR TITLE
Fix: Use the line breaks provided by OS

### DIFF
--- a/src/lib/rules/performance-budget/connections.ts
+++ b/src/lib/rules/performance-budget/connections.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Loads the connections.ini and updates it if needed
  */
-
+import * as os from 'os';
 import { readFile } from '../../utils/misc';
 import { NetworkConfig } from './types';
 
@@ -57,9 +57,13 @@ const getConnections = (): Array<NetworkConfig> => {
     const configContent = readFile(`${__dirname}/connections.ini`);
 
     const configsText = configContent
-        .replace(/\r/, '') // normalize line endings just in case
         .replace(/#.*?\n/g, '') // remove comments
-        .split('\n\n');
+        .split(`${os.EOL}${os.EOL}`);
+        /**
+         * https://nodejs.org/api/os.html#os_os_eol
+         * \n on POSIX
+         * \r\n on Windows
+         */
 
     const configs = configsText.map(parseConnection);
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
On windows `.replace(/\r/, '')` only replaced the first occurrence of `\r`, and the `split` doesn't work properly. Change it to `os.EOL` so that it works throughout different OS.


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
