### PR TITLE
New: Add `connector-edge`

### DIFF
--- a/packages/connector-edge/LICENSE.txt
+++ b/packages/connector-edge/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright JS Foundation and other contributors, https://js.foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/connector-edge/README.md
+++ b/packages/connector-edge/README.md
@@ -1,0 +1,68 @@
+# @sonarwhal/connector-edge
+
+A connector to use Microsoft Edge via the [edge diagnostics adapter](https://github.com/Microsoft/edge-diagnostics-adapter)
+in `sonarwhal`.
+
+## Installation
+
+First, you need to install [`sonarwhal`](https://sonarwhal.com/):
+
+```bash
+npm install sonarwhal
+```
+
+Then, install the new connector:
+
+```bash
+npm install @sonarwhal/connector-edge
+```
+
+## Known issues
+
+* This connector needs to be run as `Administrator`.
+* `onLoadingFailed` event is not dispatched.
+* `Security` is not implemented.
+* Edge has to open a URL by default so, before navigate,
+  you can get some events for that URL. To avoid that,
+  you should enable the property `useTabUrl` to `true`
+  and then set the property `tabUrl` with an url to an empty
+  html in the connector options. You can use the url
+  `https://empty.sonarwhal.com/`.
+
+## Usage
+
+Configure the connector name in your `.sonarwhalrc` configuration file:
+
+```json
+{
+    "connector": {
+        "name": "connector-edge"
+    }
+}
+```
+
+Configure the adapter to use an empty HTML opening a new
+browser or tab:
+
+```json
+{
+    "connector": {
+        "name": "connector-edge",
+        "options": {
+            "useTabUrl": true,
+            "tabUrl": "https://empty.sonarwhal.com/"
+        }
+    }
+}
+```
+
+## Code of Conduct
+
+This project adheres to the [JS Foundation's code of
+conduct](https://js.foundation/community/code-of-conduct).
+
+By participating in this project you agree to abide by its terms.
+
+## License
+
+The code is available under the [Apache 2.0 license](LICENSE.txt).

--- a/packages/connector-edge/appveyor.yml
+++ b/packages/connector-edge/appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+   - nodejs_version: "LTS"
+   - nodejs_version: 6
+   # will add 9/"Stable" once edge-diagnostics-adapter has a build for it
+
+# Install scripts (runs after repo cloning).
+install:
+  - ps: Install-Product node $env:nodejs_version x64
+  - node --version
+  - npm --version
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  - npm run build
+
+# Don't actually build.
+build: off

--- a/packages/connector-edge/package.json
+++ b/packages/connector-edge/package.json
@@ -1,0 +1,57 @@
+{
+  "dependencies": {
+    "edge-diagnostics-adapter": "^0.6.0",
+    "node-windows": "^0.1.14"
+  },
+  "description": "sonarwhal connector for Microsoft Edge",
+  "devDependencies": {
+    "eslint": "^4.17.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-markdown": "^1.0.0-beta.7",
+    "eslint-plugin-typescript": "^0.8.1",
+    "markdownlint-cli": "^0.7.0",
+    "npm-run-all": "^4.1.2",
+    "sonarwhal": "^0.24.0",
+    "typescript": "^2.6.2",
+    "typescript-eslint-parser": "^13.0.0"
+  },
+  "peerDependencies": {
+    "sonarwhal": "^0.24.0"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "files": [
+    "dist/src",
+    "scripts",
+    "npm-shrinkwrap.json"
+  ],
+  "homepage": "https://sonarwhal.com/",
+  "keywords": [
+    "connector",
+    "edge",
+    "microsoft edge",
+    "sonarwhal",
+    "sonarwhal-connector-edge"
+  ],
+  "license": "Apache-2.0",
+  "main": "./dist/src/index.js",
+  "name": "@sonarwhal/connector-edge",
+  "os": [
+    "win32"
+  ],
+  "repository": "sonarwhal/sonarwhal",
+  "scripts": {
+    "build": "npm run clean && npm-run-all build:*",
+    "build:ts": "tsc",
+    "clean": "rimraf dist",
+    "lint": "npm-run-all lint:*",
+    "lint:md": "markdownlint README.md",
+    "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",
+    "preinstall": "node scripts/preinstall.js",
+    "test": "echo",
+    "watch": "npm run build && npm-run-all --parallel -c watch:*",
+    "watch:ts": "npm run build:ts -- --watch"
+  },
+  "version": "1.0.0"
+}

--- a/packages/connector-edge/scripts/preinstall.js
+++ b/packages/connector-edge/scripts/preinstall.js
@@ -1,0 +1,33 @@
+const os = require('os');
+const minVersion = 15063;
+
+const printError = (message) => {
+    console.error(`${message} @sonarwhal/connector-edge will not be installed.`);
+};
+
+if (os.platform() !== 'win32') {
+    printError('Not the right platform.');
+
+    return 1;
+}
+
+const versionRegex = /^10\.0\.(\d+)$/i;
+const results = os.release().match(versionRegex);
+
+if (!Array.isArray(results)) {
+    printError('Not running on Windows 10.');
+
+    return 1;
+}
+
+const version = parseInt(results[1]);
+
+if (version <= minVersion) {
+    printError(`Running on Win10 build ${version}, minimum required is ${minVersion}.`);
+
+    return 1;
+}
+
+console.log(`Running on Win10 build ${version}`);
+
+return 0;

--- a/packages/connector-edge/src/connector-edge-launcher.ts
+++ b/packages/connector-edge/src/connector-edge-launcher.ts
@@ -1,0 +1,181 @@
+/**
+ * @fileoverview Launches the given browser with the right configuration to be used via the Chrome Debugging Protocol
+ *
+ * Supported browsers: Microsoft Edge 15
+ *
+ */
+
+/* eslint-disable no-sync */
+
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+
+import { debug as d } from 'sonarwhal/dist/src/lib/utils/debug';
+import { delay } from 'sonarwhal/dist/src/lib/utils/misc';
+import { Launcher } from 'sonarwhal/dist/src/lib/connectors/debugging-protocol-common/launcher';
+import * as logging from 'sonarwhal/dist/src/lib/utils/logging';
+import { BrowserInfo, LauncherOptions } from 'sonarwhal/dist/src/lib/types';
+import * as nodeWindows from 'node-windows';
+
+const diagnosticsPath = require.resolve('edge-diagnostics-adapter');
+const elevate = promisify(nodeWindows.elevate);
+
+const debug = d(__filename);
+
+export class EdgeLauncher extends Launcher {
+    private retryDelay: number = 500;
+
+    public constructor(options: LauncherOptions) {
+        super(options);
+    }
+
+    /** Removes all references to the client used by `isDebuggerReady`. */
+    private cleanup(client: net.Socket) {
+        client.removeAllListeners();
+        client.end();
+        client.destroy();
+        client.unref();
+    }
+
+    /** Checks if the debugger is ready by trying to connect to the default port. */
+    private isDebuggerReady(): Promise<{}> {
+        return new Promise((resolve, reject) => {
+            const client = net.createConnection(this.port);
+
+            client.once('error', (err) => {
+                this.cleanup(client);
+                reject(err);
+            });
+            client.once('connect', () => {
+                this.cleanup(client);
+                resolve();
+            });
+        });
+    }
+
+    /** Waits until the debugger is ready to accept commands or if there have been too many retries. */
+    private waitUntilReady() {
+        return new Promise((resolve, reject) => {
+            let retries = 0;
+
+            const poll = () => {
+                retries++;
+                debug('Wait for browser.');
+
+                this.isDebuggerReady()
+                    .then(() => {
+                        debug('Browser ready');
+                        resolve();
+                    })
+                    .catch((err) => {
+                        if (retries > 10) {
+                            debug(`Browser didn't initialized in the allocated time`);
+                            reject(err);
+
+                            return;
+                        }
+
+                        setTimeout(() => {
+                            poll();
+                        }, this.retryDelay);
+
+                        return;
+                    });
+            };
+
+            poll();
+        });
+    }
+
+    /**
+     * Test if we are running sonarwhal in a Windows 10 machine
+     */
+    private isWin10() {
+        return {
+            isWin: (/^win/).test(process.platform),
+            version: parseInt(os.release().split('.')[0], 10)
+        };
+    }
+
+    private checkIfRunning(procs: Array<string>): Promise<Array<boolean>> {
+        return new Promise((resolve, reject) => {
+            const cmd = spawn('cmd');
+            let out = [];
+
+            cmd.stdout.on('data', (data) => {
+                out = out.concat(data);
+            });
+
+            cmd.on('exit', () => {
+                const data = out.toString();
+
+                const result = procs.map((proc) => {
+                    return data.includes(proc);
+                });
+
+                resolve(result);
+            });
+
+            cmd.stderr.on('data', () => {
+                reject('Error getting processes');
+            });
+
+            cmd.on('error', (err) => {
+                reject(err);
+            });
+
+            cmd.stdin.write('wmic process get ProcessId,CommandLine \n');
+            cmd.stdin.end();
+        });
+    }
+
+    public async launch(url): Promise<BrowserInfo> {
+        const osInfo = this.isWin10();
+
+        if (!osInfo.isWin || osInfo.version < 10) {
+            const message = 'Edge diagnostics adapter needs windows 10';
+
+            logging.error(message);
+            throw new Error(message);
+        }
+
+        const [isEdgeAdapterRunning, isEdgeRunning] = await this.checkIfRunning(['edgeAdapter.js', 'MicrosoftEdge.exe']);
+
+        if (!isEdgeAdapterRunning) {
+            await elevate(`"${process.execPath}" ${diagnosticsPath} --servetools --diagnostics --port=${this.port}`, {});
+        }
+
+        await this.waitUntilReady();
+
+        if (!isEdgeRunning) {
+            const outFile2 = fs.openSync(path.join(process.cwd(), 'edge-out.log'), 'a');
+            const errFile2 = fs.openSync(path.join(process.cwd(), 'edge-err.log'), 'a');
+
+            const child2 = spawn(`start microsoft-edge:${url === 'about:blank' ? '' : url}`, [], {
+                detached: true,
+                shell: true,
+                stdio: ['ignore', outFile2, errFile2]
+            });
+
+            child2.unref();
+
+            await delay(3000);
+
+            return {
+                isNew: true,
+                pid: -1,
+                port: this.port
+            };
+        }
+
+        return {
+            isNew: false,
+            pid: -1,
+            port: this.port
+        };
+    }
+}

--- a/packages/connector-edge/src/connector-edge.ts
+++ b/packages/connector-edge/src/connector-edge.ts
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Connector for Edge 15 that uses [edge-diagnostics-adapter](https://github.com/Microsoft/Edge-diagnostics-adapter)
+ * to load a site and do the traversing.
+ */
+
+import { Connector } from 'sonarwhal/dist/src/lib/connectors/debugging-protocol-common/debugging-protocol-connector';
+import { IConnector, IConnectorBuilder, ILauncher } from 'sonarwhal/dist/src/lib/types';
+import { EdgeLauncher } from './connector-edge-launcher';
+
+import { Sonarwhal } from 'sonarwhal/dist/src/lib/sonarwhal';
+
+class EdgeConnector extends Connector {
+    public constructor(server: Sonarwhal, config: object, launcher: ILauncher) {
+        super(server, config, launcher);
+    }
+}
+
+const builder: IConnectorBuilder = (server: Sonarwhal, config): IConnector => {
+    const edgeRequiredConfig = {
+        tabUrl: 'https://empty.sonarwhal.com/',
+        useTabUrl: true
+    };
+    const edgeConfig = Object.assign({}, edgeRequiredConfig, config);
+    const launcher = new EdgeLauncher(edgeConfig);
+    const collector = new EdgeConnector(server, edgeConfig, launcher);
+
+    return collector;
+};
+
+export default builder;

--- a/packages/connector-edge/src/index.ts
+++ b/packages/connector-edge/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview Edge Diagnostics Adapter connector for sonarwhal.
+ */
+
+import * as eda from './connector-edge';
+
+module.exports = eda;

--- a/packages/connector-edge/tsconfig.json
+++ b/packages/connector-edge/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "exclude": [
+        "dist",
+        "node_modules"
+    ],
+    "extends": "../../tsconfig.json",
+    "include": [
+        "src/**/*.ts",
+        "tests/**/*.ts"
+    ]
+}


### PR DESCRIPTION
This add the code from https://github.com/sonarwhal/connector-edge into the main repo.

To test this you need to manually do a `npm install`, otherwise `yarn` will complain on Windows (and this connector only runs on Windows).
