### PR TITLE
Chore: Add `json` to content types

### DIFF
--- a/packages/sonarwhal/src/lib/utils/content-type.ts
+++ b/packages/sonarwhal/src/lib/utils/content-type.ts
@@ -386,6 +386,11 @@ const isTextMediaType = (mediaType: string): boolean => {
  * or `unkown`.
  */
 const getType = (mediaType: string) => {
+    // e.g, `.babelrc`, mediaType can't be decided from extension or from the file type.
+    if (!mediaType) {
+        return 'unknown';
+    }
+
     if (mediaType.startsWith('image')) {
         return 'image';
     }
@@ -399,6 +404,8 @@ const getType = (mediaType: string) => {
             return 'script';
         case 'text/css':
             return 'css';
+        case 'application/json':
+            return 'json';
         case 'application/manifest+json':
             return 'manifest';
         case 'text/html':


### PR DESCRIPTION


<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
1. Take care of the case when there is no `mediaType`.
2. Add `json` to content type options.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
