### PR TITLE
Fix: Install rules before validate

### DIFF
--- a/packages/sonarwhal/src/lib/cli/analyze.ts
+++ b/packages/sonarwhal/src/lib/cli/analyze.ts
@@ -153,15 +153,15 @@ export const analyze = async (actions: CLIOptions): Promise<boolean> => {
         });
 
         if (!(await askUserToInstallDependencies(resources.missing.concat(resources.incompatible)) &&
-              await installPackages(missingPackages) &&
-              await installPackages(incompatiblePackages))) {
+            await installPackages(missingPackages) &&
+            await installPackages(incompatiblePackages))) {
 
             // The user doesn't want to install the dependencies or something went wrong installing them
             return false;
         }
     }
 
-    const invalidConfigRules = SonarwhalConfig.validateRuleConfig(config);
+    const invalidConfigRules = SonarwhalConfig.validateRulesConfig(config).invalid;
 
     if (invalidConfigRules.length > 0) {
         logger.error(`Invalid rule configuration in .sonarwhalrc: ${invalidConfigRules.join(', ')}.`);

--- a/packages/sonarwhal/src/lib/cli/analyze.ts
+++ b/packages/sonarwhal/src/lib/cli/analyze.ts
@@ -161,6 +161,14 @@ export const analyze = async (actions: CLIOptions): Promise<boolean> => {
         }
     }
 
+    const invalidConfigRules = SonarwhalConfig.validateRuleConfig(config);
+
+    if (invalidConfigRules.length > 0) {
+        logger.error(`Invalid rule configuration in .sonarwhalrc: ${invalidConfigRules.join(', ')}.`);
+
+        return false;
+    }
+
     sonarwhal = new Sonarwhal(config, resources);
 
     const start: number = Date.now();

--- a/packages/sonarwhal/tests/lib/cli/analyze.ts
+++ b/packages/sonarwhal/tests/lib/cli/analyze.ts
@@ -31,7 +31,7 @@ const config = {
     SonarwhalConfig: {
         fromFilePath() { },
         getFilenameForDirectory() { },
-        validateRuleConfig() { }
+        validateRulesConfig() { }
     }
 };
 
@@ -49,6 +49,7 @@ const ora = () => {
 };
 
 const inquirer = { prompt() { } };
+const validateRulesConfigResult = { invalid: [] };
 
 proxyquire('../../../src/lib/cli/analyze', {
     '../config': config,
@@ -99,7 +100,7 @@ test.serial('If config is not defined, it should get the config file from the di
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath')
         .onFirstCall()
         .returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
     await analyzer.analyze(actions);
 
     t.true(t.context.SonarwhalConfig.getFilenameForDirectory.called);
@@ -121,7 +122,7 @@ test.serial('If config file does not exist, it should create a configuration fil
         .throws(error)
         .onSecondCall()
         .returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
     sandbox.stub(inquirer, 'prompt').resolves({ confirm: true });
 
     await analyzer.analyze(actions);
@@ -145,7 +146,7 @@ test.serial('If config file does not exist and user refuses to create a configur
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath')
         .onFirstCall()
         .throws(error);
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
     sandbox.stub(inquirer, 'prompt').resolves({ confirm: false });
 
     const result = await analyzer.analyze(actions);
@@ -166,7 +167,7 @@ test.serial('If configuration file exists, it should use it', async (t) => {
         missing: []
     });
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     const customConfigOptions = ({ _: ['http://localhost'], config: 'configfile.cfg' } as CLIOptions);
 
@@ -197,7 +198,7 @@ test.serial('If executeOn returns an error, it should exit with code 1 and call 
         missing: []
     });
 
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     const sonarwhalObj = new sonarwhalContainer.Sonarwhal();
 
@@ -225,7 +226,7 @@ test.serial('If executeOn returns an error, it should call to spinner.fail()', a
         missing: []
     });
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').resolves([{ severity: Severity.error }]);
 
     await analyzer.analyze(actions);
@@ -244,7 +245,7 @@ test.serial('If executeOn throws an exception, it should exit with code 1', asyn
     });
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').throws(new Error());
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     const result = await analyzer.analyze(actions);
 
@@ -262,7 +263,7 @@ test.serial('If executeOn throws an exception, it should call to spinner.fail()'
     });
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').throws(new Error());
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 
@@ -299,7 +300,7 @@ test.serial('If executeOn returns no errors, it should exit with code 0 and call
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
 
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     const exitCode = await analyzer.analyze(actions);
 
@@ -337,7 +338,7 @@ test.serial('If executeOn returns no errors, it should call to spinner.succeed()
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
 
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 
@@ -375,7 +376,7 @@ test.serial('Event fetch::start should write a message in the spinner', async (t
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 
@@ -413,7 +414,7 @@ test.serial('Event fetch::end should write a message in the spinner', async (t) 
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 
@@ -451,7 +452,7 @@ test.serial('Event fetch::end::manifest should write a message in the spinner', 
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 
@@ -489,7 +490,7 @@ test.serial('Event fetch::end::html should write a message in the spinner', asyn
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 
@@ -527,7 +528,7 @@ test.serial('Event traverse::up should write a message in the spinner', async (t
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 
@@ -565,7 +566,7 @@ test.serial('Event traverse::end should write a message in the spinner', async (
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 
@@ -603,7 +604,7 @@ test.serial('Event scan::end should write a message in the spinner', async (t) =
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
-    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
     await analyzer.analyze(actions);
 

--- a/packages/sonarwhal/tests/lib/cli/analyze.ts
+++ b/packages/sonarwhal/tests/lib/cli/analyze.ts
@@ -30,7 +30,8 @@ const logger = {
 const config = {
     SonarwhalConfig: {
         fromFilePath() { },
-        getFilenameForDirectory() { }
+        getFilenameForDirectory() { },
+        validateRuleConfig() { }
     }
 };
 
@@ -98,6 +99,7 @@ test.serial('If config is not defined, it should get the config file from the di
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath')
         .onFirstCall()
         .returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
     await analyzer.analyze(actions);
 
     t.true(t.context.SonarwhalConfig.getFilenameForDirectory.called);
@@ -119,6 +121,7 @@ test.serial('If config file does not exist, it should create a configuration fil
         .throws(error)
         .onSecondCall()
         .returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
     sandbox.stub(inquirer, 'prompt').resolves({ confirm: true });
 
     await analyzer.analyze(actions);
@@ -142,6 +145,7 @@ test.serial('If config file does not exist and user refuses to create a configur
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath')
         .onFirstCall()
         .throws(error);
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
     sandbox.stub(inquirer, 'prompt').resolves({ confirm: false });
 
     const result = await analyzer.analyze(actions);
@@ -162,6 +166,7 @@ test.serial('If configuration file exists, it should use it', async (t) => {
         missing: []
     });
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     const customConfigOptions = ({ _: ['http://localhost'], config: 'configfile.cfg' } as CLIOptions);
 
@@ -192,6 +197,8 @@ test.serial('If executeOn returns an error, it should exit with code 1 and call 
         missing: []
     });
 
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
+
     const sonarwhalObj = new sonarwhalContainer.Sonarwhal();
 
     sandbox.stub(sonarwhalObj, 'formatters').get(() => {
@@ -218,6 +225,7 @@ test.serial('If executeOn returns an error, it should call to spinner.fail()', a
         missing: []
     });
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').resolves([{ severity: Severity.error }]);
 
     await analyzer.analyze(actions);
@@ -236,6 +244,7 @@ test.serial('If executeOn throws an exception, it should exit with code 1', asyn
     });
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').throws(new Error());
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     const result = await analyzer.analyze(actions);
 
@@ -253,6 +262,7 @@ test.serial('If executeOn throws an exception, it should call to spinner.fail()'
     });
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').throws(new Error());
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 
@@ -289,6 +299,7 @@ test.serial('If executeOn returns no errors, it should exit with code 0 and call
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
 
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     const exitCode = await analyzer.analyze(actions);
 
@@ -326,6 +337,7 @@ test.serial('If executeOn returns no errors, it should call to spinner.succeed()
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
 
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 
@@ -363,6 +375,7 @@ test.serial('Event fetch::start should write a message in the spinner', async (t
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 
@@ -400,6 +413,7 @@ test.serial('Event fetch::end should write a message in the spinner', async (t) 
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 
@@ -437,6 +451,7 @@ test.serial('Event fetch::end::manifest should write a message in the spinner', 
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 
@@ -474,6 +489,7 @@ test.serial('Event fetch::end::html should write a message in the spinner', asyn
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 
@@ -511,6 +527,7 @@ test.serial('Event traverse::up should write a message in the spinner', async (t
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 
@@ -548,6 +565,7 @@ test.serial('Event traverse::end should write a message in the spinner', async (
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 
@@ -585,6 +603,7 @@ test.serial('Event scan::end should write a message in the spinner', async (t) =
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'fromFilePath').returns({});
+    sandbox.stub(t.context.SonarwhalConfig, 'validateRuleConfig').returns([]);
 
     await analyzer.analyze(actions);
 

--- a/packages/sonarwhal/tests/lib/config.ts
+++ b/packages/sonarwhal/tests/lib/config.ts
@@ -249,12 +249,9 @@ test.serial(`if a Rule has an invalid configuration, it should throw an exceptio
 
     sandbox.stub(resourceLoader, 'loadRule').returns(FakeDisallowedRule);
 
-    t.plan(1);
-    try {
-        config.SonarwhalConfig.fromFilePath(path.join(__dirname, './fixtures/valid/package.json'), { watch: false } as CLIOptions);
-    } catch (err) {
-        t.is(err.message, 'Rule disallowed-headers has an invalid configuration');
-    }
+    const configuration = config.SonarwhalConfig.fromFilePath(path.join(__dirname, './fixtures/valid/package.json'), { watch: false } as CLIOptions);
+    const invalidConfigRules = config.SonarwhalConfig.validateRuleConfig(configuration);
 
+    t.is(invalidConfigRules.length, 1);
     sandbox.restore();
 });

--- a/packages/sonarwhal/tests/lib/config.ts
+++ b/packages/sonarwhal/tests/lib/config.ts
@@ -250,8 +250,8 @@ test.serial(`if a Rule has an invalid configuration, it should throw an exceptio
     sandbox.stub(resourceLoader, 'loadRule').returns(FakeDisallowedRule);
 
     const configuration = config.SonarwhalConfig.fromFilePath(path.join(__dirname, './fixtures/valid/package.json'), { watch: false } as CLIOptions);
-    const invalidConfigRules = config.SonarwhalConfig.validateRuleConfig(configuration);
+    const { invalid } = config.SonarwhalConfig.validateRulesConfig(configuration);
 
-    t.is(invalidConfigRules.length, 1);
+    t.is(invalid.length, 1);
     sandbox.restore();
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)
In the current code, if a rule has not been installed, when user scans a site, an error is thrown and the user will be asked to re-generate a valid `.sonarwhalrc` even though there already is one. The correct behavior should be prompt to ask the user if they want to install the missing rules first. So this PR moves the validation of rule configurations after the rules have been installed.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
