### PR TITLE
Fix: Validate resource name on load

### DIFF
--- a/packages/sonarwhal/src/lib/utils/misc.ts
+++ b/packages/sonarwhal/src/lib/utils/misc.ts
@@ -145,6 +145,11 @@ const normalizeStringByDelimiter = (value: string, delimiter: string) => {
     return normalizeString(value).replace(/[^a-z0-9]/gi, delimiter);
 };
 
+/** Return if normalized `source` string includes normalized `included` string. */
+const isNormalizedIncluded = (source: string, included: string) => {
+    return normalizeString(source).includes(normalizeString(included));
+};
+
 /** Convert '-' delimitered string to camel case name. */
 const toCamelCase = (value: string) => {
     return value.split('-').reduce((accu: string, w: string) => {
@@ -321,6 +326,7 @@ const getSonarwhalPackage = () => {
 export {
     cutString,
     delay,
+    isNormalizedIncluded,
     findNodeModulesRoot,
     findPackageRoot,
     getFileExtension,


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)
* Change the path to load external rules back to `process.cwd()`.
* Add additional check to verify the name of the resource loaded.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
