### PR TITLE
Fix: Allow packageName to be added in tests

### DIFF
--- a/packages/sonarwhal/src/lib/utils/rule-helpers.ts
+++ b/packages/sonarwhal/src/lib/utils/rule-helpers.ts
@@ -35,7 +35,7 @@ export const getIncludedHeaders = (headers: object, headerList: Array<string> = 
  * * `/something/rule-another/` --> `another`
  * * `/something/rule-another` --> `another`
  */
-export const getRuleName = (dirname: string, packageName: string): string => {
+export const getRuleName = (dirname: string, packageName?: string): string => {
     const parts = dirname.split(path.sep);
     let ruleName = '';
 

--- a/packages/sonarwhal/src/lib/utils/rule-helpers.ts
+++ b/packages/sonarwhal/src/lib/utils/rule-helpers.ts
@@ -35,8 +35,9 @@ export const getIncludedHeaders = (headers: object, headerList: Array<string> = 
  * * `/something/rule-another/` --> `another`
  * * `/something/rule-another` --> `another`
  */
-export const getRuleName = (dirname: string): string => {
+export const getRuleName = (dirname: string, packageName: string): string => {
     const parts = dirname.split(path.sep);
+    let ruleName = '';
 
     const normalize = (name) => {
         return name.replace('rule-', '');
@@ -44,11 +45,13 @@ export const getRuleName = (dirname: string): string => {
 
     for (let i = 0; i < parts.length; i++) {
         if (parts[i].startsWith('rule-') || (parts[i - 1] && parts[i - 1].startsWith('rules'))) {
-            return normalize(parts[i]);
+            ruleName = normalize(parts[i]);
+
+            return packageName ? `${packageName}/${ruleName}` : ruleName;
         }
     }
 
-    return '';
+    return ruleName;
 };
 
 /**

--- a/packages/sonarwhal/tests/lib/utils/rule-helpers.ts
+++ b/packages/sonarwhal/tests/lib/utils/rule-helpers.ts
@@ -142,3 +142,16 @@ test.serial(`getRuleName - returns an empty string if it can't determine the rul
 
     t.deepEqual(ruleName, '');
 });
+
+test.serial(`getRuleName - returns a combined string if a package name is passed`, (t) => {
+    const sandbox = sinon.createSandbox();
+
+    sandbox.stub(path, 'sep').get(() => {
+        return '/';
+    });
+
+    const filePath = '/another/rule-something';
+    const ruleName = ruleHelpers.getRuleName(filePath, 'package');
+
+    t.deepEqual(ruleName, 'package/something');
+});


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)
Allow package names to be added to the ruleIds in tests, otherwise the rules can't get loaded correctly.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
