### PR TITLE
Fix: Handle when `parsers` are not defined

### DIFF
--- a/packages/sonarwhal/src/lib/utils/resource-loader.ts
+++ b/packages/sonarwhal/src/lib/utils/resource-loader.ts
@@ -295,11 +295,13 @@ export const loadResource = (name: string, type: ResourceType, configurations: A
 const loadListOfResources = (list: Array<string> | Object = [], type: ResourceType, configurations: Array<string> = []): { incompatible: Array<string>, missing: Array<string>, resources: Array<any> } => {
     const missing: Array<string> = [];
     const incompatible: Array<string> = [];
+    // In case `Parsers` are not defined by the user.
+    const safeList: Array<string> | Object = list || [];
 
     // In the case of rules, we get an object with rulename/priority, not an array
-    const items = Array.isArray(list) ?
-        list :
-        Object.keys(list);
+    const items = Array.isArray(safeList) ?
+    safeList :
+        Object.keys(safeList);
 
     const loadedResources = items.reduce((loaded, resourceId) => {
         try {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)
It doesn't seem to be right that  the scanner fails if `Parsers` are not defined in `.sonarwhalrc`, the `Parsers` are empty most of the time so it's probably not ideal to force the user to put `"Parsers":[]` there. Or if we want to reinforce that, we need to make the error message more friendly.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
