### PR TITLE
Chore: Use `packageName` instead of `key`

### DIFF
--- a/packages/sonarwhal/src/lib/utils/resource-loader.ts
+++ b/packages/sonarwhal/src/lib/utils/resource-loader.ts
@@ -263,7 +263,7 @@ export const loadResource = (name: string, type: ResourceType, configurations: A
                 try {
                     const packageConfig = getPackage(source);
 
-                    if (!isNormalizedIncluded(packageConfig.name, key)) {
+                    if (!isNormalizedIncluded(packageConfig.name, packageName)) {
                         return false;
                     }
                 } catch (e) {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [ ] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

The `key` now includes both the package and rule name.
So it shouldn't be used to validate the package name only.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
