### PR TITLE
Fix: Handle undefined ignoredUrls

### DIFF
--- a/packages/sonarwhal/src/lib/sonarwhal.ts
+++ b/packages/sonarwhal/src/lib/sonarwhal.ts
@@ -154,7 +154,7 @@ export class Sonarwhal extends EventEmitter {
         const createEventHandler = (handler: Function, ruleId: string) => {
             return function (event: Event): Promise<any> {
                 const urlsIgnoredForAll = that.ignoredUrls.get('all');
-                const urlsIgnored: Array<RegExp> = !urlsIgnoredForAll ? that.ignoredUrls.get(ruleId) : that.ignoredUrls.get(ruleId).concat(urlsIgnoredForAll);
+                const urlsIgnored: Array<RegExp> = !urlsIgnoredForAll ? that.ignoredUrls.get(ruleId) : that.ignoredUrls.get(ruleId) ? that.ignoredUrls.get(ruleId).concat(urlsIgnoredForAll) : urlsIgnoredForAll;
 
                 if (that.isIgnored(urlsIgnored, event.resource)) {
                     return null;

--- a/packages/sonarwhal/src/lib/sonarwhal.ts
+++ b/packages/sonarwhal/src/lib/sonarwhal.ts
@@ -153,8 +153,9 @@ export class Sonarwhal extends EventEmitter {
 
         const createEventHandler = (handler: Function, ruleId: string) => {
             return function (event: Event): Promise<any> {
-                const urlsIgnoredForAll = that.ignoredUrls.get('all');
-                const urlsIgnored: Array<RegExp> = !urlsIgnoredForAll ? that.ignoredUrls.get(ruleId) : that.ignoredUrls.get(ruleId) ? that.ignoredUrls.get(ruleId).concat(urlsIgnoredForAll) : urlsIgnoredForAll;
+                const urlsIgnoredForAll = that.ignoredUrls.get('all') ? that.ignoredUrls.get('all') : [];
+                const urlsIgnoredForRule = that.ignoredUrls.get(ruleId) ? that.ignoredUrls.get(ruleId) : [];
+                const urlsIgnored = urlsIgnoredForRule.concat(urlsIgnoredForAll);
 
                 if (that.isIgnored(urlsIgnored, event.resource)) {
                     return null;


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

I encountered a bug when running sonarwhal with a configuration like this:

```json
{
    "connector": {
        "name": "chrome",
        "options": {
            "waitFor": 1000
        }
    },
    "formatters": [
        "stylish"
    ],
    "ignoredUrls": [
        {
            "domain": ".*fonts\\.googleapis\\.com/.*",
            "rules": [
                "*"
            ]
        }
    ],
    "rules": {
        "ssllabs": "error"
    },
    "rulesTimeout": 120000
}
```

The error says:

```txt
Unhandled rejection promise:
    uri: undefined
    message: Cannot read property 'concat' of undefined
    stack:
```

I guess this is because I specified an ignoredUrl for all rules but haven't specified a ingnoredUrl which is only valid for the ssllabs rule. I therefore inserted another ternary operator to handle that case.

I ran the test tests. They are still passing.