### PR TITLE
Fix: Not to error when no config path is found

### DIFF
--- a/packages/sonarwhal/src/lib/cli/analyze.ts
+++ b/packages/sonarwhal/src/lib/cli/analyze.ts
@@ -63,6 +63,18 @@ const tryToLoadConfig = async (actions: CLIOptions): Promise<SonarwhalConfig> =>
     let config: SonarwhalConfig;
     const configPath: string = actions.config || SonarwhalConfig.getFilenameForDirectory(process.cwd());
 
+    if (!configPath) {
+        logger.error(`Couldn't find a valid path to load the configuration file.`);
+
+        const created = await askUserToCreateConfig();
+
+        if (created) {
+            config = await tryToLoadConfig(actions);
+        }
+
+        return config;
+    }
+
     debug(`Loading configuration file from ${configPath}.`);
     try {
         config = SonarwhalConfig.fromFilePath(configPath, actions);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)
Fix #874
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
