### PR TITLE
Fix: Call `format`s asynchronously

### DIFF
--- a/packages/sonarwhal/package.json
+++ b/packages/sonarwhal/package.json
@@ -8,6 +8,7 @@
   },
   "bin": "./dist/src/bin/sonarwhal.js",
   "dependencies": {
+    "async": "^2.6.0",
     "browserslist": "^3.1.2",
     "canvas-prebuilt": "^1.6.5-prerelease.1",
     "chalk": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,7 +655,7 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.0, async@^2.1.4:
+async@^2.0.0, async@^2.1.4, async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

There were some reports that Excel formatter was generating just an empty file. It turns out it's the first `formatter` that actually requires to be called asynchronously.

This PR makes the call to `formatter.format` using `await`.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
