### PR TITLE
Fix: Fail if response from `ssllabs` is empty

### DIFF
--- a/packages/rule-ssllabs/src/rule.ts
+++ b/packages/rule-ssllabs/src/rule.ts
@@ -189,7 +189,7 @@ export default class SSLLabsRule implements IRule {
 
             debug(`Received SSL Labs results for ${resource}`);
 
-            if (!host.endpoints || host.endpoints.length === 0) {
+            if (!host || !host.endpoints || host.endpoints.length === 0) {
                 const msg = `Didn't get any result for ${resource}.
 There might be something wrong with SSL Labs servers.`;
 

--- a/packages/rule-ssllabs/tests/tests.ts
+++ b/packages/rule-ssllabs/tests/tests.ts
@@ -12,7 +12,7 @@ const ssllabsMock = (response) => {
     const mockedModule = {
         // Original node-ssllabs uses callback and we promisify in the rule
         scan: (options, callback) => {
-            if (!response) {
+            if (response === null) {
                 return callback('Error');
             }
 
@@ -117,6 +117,17 @@ There might be something wrong with SSL Labs servers.`
         serverUrl: 'https://example.com',
         before() {
             ssllabsMock({ endpoints: [] });
+        }
+    },
+    {
+        name: 'Response with right status code but nothing inside reports an error',
+        reports: [{
+            message: `Didn't get any result for https://example.com/.
+There might be something wrong with SSL Labs servers.`
+        }],
+        serverUrl: 'https://example.com',
+        before() {
+            ssllabsMock(undefined);
         }
     }
 ];


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related tests.

## Short description of the change(s)

Fix #848

In some cases the `ssllabs` server returns an empty json response with status code 200 that breaks our code. This PR fixes that and adds a test for that.


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
