### PR TITLE
Fix: Require `crossorigin` for `stylesheets` too

### DIFF
--- a/packages/rule-sri/README.md
+++ b/packages/rule-sri/README.md
@@ -35,7 +35,7 @@ This rule checks that a website uses correctly SRI, more especifically:
   If multiple ones are provided, the highest one will be used to determine if
   the baseline is met.
 * When using a cross-origin resource (e.g.: using a script hosted in a third
-  party CDN), the `<script>` tag needs to have a valid
+  party CDN), the `<script>` or `<link>` tag needs to have a valid
   [`crossorigin` attribute][crossorigin].
 * The resource is served on a [secure context][secure context] (i.e.: HTTPS) to
   guarantee the HTML and resource haven't been tampered during the delivery.

--- a/packages/rule-sri/src/rule.ts
+++ b/packages/rule-sri/src/rule.ts
@@ -113,11 +113,6 @@ export default class SRIRule implements IRule {
         const { element, resource } = evt;
         const resourceOrigin: string = new URL(resource).origin;
 
-        // CORS validation only applies to scripts, styles are OK
-        if (element.nodeName !== 'SCRIPT') {
-            return true;
-        }
-
         if (this.origin === resourceOrigin) {
             return true;
         }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [X] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Force the check of `crossorigin` attribute in `link` tags too.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
