### PR TITLE
Fix: Always generate a valid file

### DIFF
--- a/packages/formatter-excel/src/excel.ts
+++ b/packages/formatter-excel/src/excel.ts
@@ -65,15 +65,20 @@ export default class ExcelFormatter implements IFormatter {
             }
         }, border);
 
+        const names: Map<string, string> = new Map();
         /**
          * Replaces `://`, `/`, `.` for `-` so the names are compatible with the sheets
          */
         const getName = (name: string) => {
-            return name
-                .replace(/:\/\//g, '-')
-                .replace(/\./g, '-')
-                .replace(/\//g, '-')
-                .replace(/-$/, '');
+            if (names.has(name)) {
+                return names.get(name);
+            }
+
+            const finalName = `resource-${names.size}`;
+
+            names.set(name, finalName);
+
+            return finalName;
         };
 
         /** Applies all the given properties to `cell`. */
@@ -185,7 +190,10 @@ export default class ExcelFormatter implements IFormatter {
 
         try {
             // We save the file with the friendly target name
-            const name = getName(target);
+            const name = target.replace(/:\/\//g, '-')
+                .replace(/\./g, '-')
+                .replace(/\//g, '-')
+                .replace(/-$/, '');
 
             await workbook.xlsx.writeFile(`${process.cwd()}/${name}.xlsx`);
         } catch (e) {

--- a/packages/formatter-excel/tests/excel.ts
+++ b/packages/formatter-excel/tests/excel.ts
@@ -49,7 +49,7 @@ test(`Excel formatter generates the right number of sheets with the good content
     t.is(summary.actualColumnCount, 2, `summary.actualColumnCount isn't 2`);
     t.is(summary.actualRowCount, 3, `summary.actualRowCount isn't 3`);
 
-    t.is(report.name, 'http-myresource-com', 'Title is not myresource.com');
+    t.true(report.name.startsWith('resource-'), `Title doesn't start with resource-`);
     t.is(report.actualColumnCount, 2, `report.actualColumnCount isn't 2`);
     t.is(report.actualRowCount, 6, `report.actualRowCount isn't 3`);
 


### PR DESCRIPTION

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Excel limits the length of the name of a sheet to 31. This changes the
value for the resources sheets to `resource-XX` to avoid this problem.


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
