### PR TITLE
Fix: Update `schema` to valid one

### DIFF
--- a/packages/rule-http-compression/src/rule.ts
+++ b/packages/rule-http-compression/src/rule.ts
@@ -50,8 +50,8 @@ export default class HttpCompressionRule implements IRule {
                 }
             },
             properties: {
-                resource: { $ref: '#/definitions/options' },
-                target: { $ref: '#/definitions/options' }
+                html: { $ref: '#/definitions/options' },
+                resource: { $ref: '#/definitions/options' }
             },
             type: 'object'
         }],

--- a/packages/rule-http-compression/tests/tests-https.ts
+++ b/packages/rule-http-compression/tests/tests-https.ts
@@ -43,15 +43,15 @@ ruleRunner.testRule(ruleName, testsForBrotliSmallSize, testConfigs);
 ruleRunner.testRule(ruleName, testsForBrotliUASniffing(), testConfigs);
 
 // Tests for the user options.
-[true, false].forEach((isTarget) => {
+[true, false].forEach((isHTML) => {
     ['gzip', 'zopfli', 'brotli'].forEach((encoding) => {
         ruleRunner.testRule(
             ruleName,
-            testsForUserConfigs(`${encoding}`, isTarget, true),
+            testsForUserConfigs(`${encoding}`, isHTML, true),
             Object.assign(
                 {},
                 testConfigs,
-                { ruleOptions: { [isTarget ? 'target' : 'resource']: { [encoding]: false } } }
+                { ruleOptions: { [isHTML ? 'html' : 'resource']: { [encoding]: false } } }
             )
         );
     });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)

The schema of this rule was using the old `target` property when it should be `html`. This change fixes that and closes #905

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
