### PR TITLE
Breaking: Make it more clear why a compression method is recommended

### DIFF
--- a/packages/rule-http-compression/src/rule.ts
+++ b/packages/rule-http-compression/src/rule.ts
@@ -106,7 +106,7 @@ export default class HttpCompressionRule implements IRule {
         };
 
         const generateCompressionMessage = (encoding: string, notRequired?: boolean, suffix?: string) => {
-            return `Should${notRequired ? ' not' : ''} be served compressed${encoding ? ` with ${encoding}` : ''}${suffix ? ` ${suffix}` : ''}.`;
+            return `Should${notRequired ? ' not' : ''} be served compressed${encoding ? ` with ${encoding}` : ''}${notRequired ? '' : ` when ${['Zopfli', 'gzip'].includes(encoding) ? 'gzip' : encoding} compression is requested`}${suffix ? `${!suffix.startsWith(',') ? ' ' : ''}${suffix}` : ''}.`;
         };
 
         const generateSizeMessage = async (resource: string, element: IAsyncHTMLElement, encoding: string, sizeDifference) => {
@@ -324,7 +324,7 @@ export default class HttpCompressionRule implements IRule {
             });
 
             if (!isCompressedWithBrotli(uaRawResponse)) {
-                await context.report(resource, element, generateCompressionMessage('Brotli', false, `over HTTPS regardless of the user agent`));
+                await context.report(resource, element, generateCompressionMessage('Brotli', false, `over HTTPS, regardless of the user agent`));
             }
         };
 
@@ -384,7 +384,7 @@ export default class HttpCompressionRule implements IRule {
 
             if (!isCompressedWithGzip(uaRawResponse) &&
                 shouldCheckIfCompressedWith.gzip) {
-                await context.report(resource, element, generateCompressionMessage('gzip', false, `regardless of the user agent`));
+                await context.report(resource, element, generateCompressionMessage('gzip', false, ', regardless of the user agent'));
 
                 return;
             }
@@ -392,7 +392,7 @@ export default class HttpCompressionRule implements IRule {
             if (isNotCompressedWithZopfli(uaRawResponse) &&
                 !notCompressedWithZopfli &&
                 shouldCheckIfCompressedWith.zopfli) {
-                await context.report(resource, element, generateCompressionMessage('Zopfli', false, `regardless of the user agent`));
+                await context.report(resource, element, generateCompressionMessage('Zopfli', false, ', regardless of the user agent'));
             }
 
         };

--- a/packages/rule-http-compression/tests/_tests.ts
+++ b/packages/rule-http-compression/tests/_tests.ts
@@ -9,7 +9,7 @@ const uaString = 'Mozilla/5.0 Gecko';
 // Error messages.
 
 const generateCompressionMessage = (encoding?: string, notRequired?: boolean, suffix?: string) => {
-    return `Should${notRequired ? ' not' : ''} be served compressed${encoding ? ` with ${encoding}` : ''}${suffix ? ` ${suffix}` : ''}.`;
+    return `Should${notRequired ? ' not' : ''} be served compressed${encoding ? ` with ${encoding}` : ''}${notRequired ? '' : ` when ${['Zopfli', 'gzip'].includes(encoding) ? 'gzip' : encoding} compression is requested`}${suffix ? `${!suffix.startsWith(',') ? ' ' : ''}${suffix}` : ''}.`;
 };
 
 const generateContentEncodingMessage = (encoding?: string, notRequired?: boolean, suffix?: string) => {
@@ -279,7 +279,7 @@ const testsForBrotliUASniffing = (): Array<RuleTest> => {
     return [
         {
             name: `Resource is not served compressed with Brotli when Brotli compression is requested with uncommon user agent string`,
-            reports: [{ message: generateCompressionMessage('Brotli', false, `over HTTPS regardless of the user agent`) }],
+            reports: [{ message: generateCompressionMessage('Brotli', false, `over HTTPS, regardless of the user agent`) }],
             serverConfig: createBrotliServerConfig(
                 Object.assign(
                     headersConfig,
@@ -556,7 +556,7 @@ const testsForGzipZopfliUASniffing = (https: boolean = false): Array<RuleTest> =
     return [
         {
             name: `Resource is not served compressed with gzip when gzip compression is requested with uncommon user agent string`,
-            reports: [{ message: generateCompressionMessage('gzip', false, `regardless of the user agent`) }],
+            reports: [{ message: generateCompressionMessage('gzip', false, `, regardless of the user agent`) }],
             serverConfig: createGzipZopfliServerConfig(
                 Object.assign(
                     headersConfig,
@@ -570,7 +570,7 @@ const testsForGzipZopfliUASniffing = (https: boolean = false): Array<RuleTest> =
         },
         {
             name: `Resource is not served compressed with Zopfli when Zopfli compression is requested with uncommon user agent string`,
-            reports: [{ message: generateCompressionMessage('Zopfli', false, `regardless of the user agent`) }],
+            reports: [{ message: generateCompressionMessage('Zopfli', false, `, regardless of the user agent`) }],
             serverConfig: createGzipZopfliServerConfig(
                 Object.assign(
                     headersConfig,

--- a/scripts/check-commit-message.js
+++ b/scripts/check-commit-message.js
@@ -59,8 +59,8 @@ const checkFirstLine = (line) => {
 
     let issues = [];
 
-    if (ucs2.decode(line).length > 50) {
-        issues.push('[Line 1] Has over 50 characters.');
+    if (ucs2.decode(line).length > 72) {
+        issues.push('[Line 1] Has over 72 characters.');
     }
 
     const tag = ALLOWED_TAGS.filter((allowedTag) => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Just specifying that it _"Should be served compressed with Zopfli"_ when the user is also informed that the same resource _"Should be served compressed with Brotli over HTTPS."_ is confusing.
    
In order to make it more clear, this commit changes the error messages so that they provide a bit more information, thus, it changes something such as "Should be served compressed with Zopfli" to _"Should be served compressed with Zopfli when gzip compression is requested"_.
    
Ref #913
Fix #914

