### PR TITLE
Docs: Update Apache configs to only support v2.4.0+

### DIFF
--- a/packages/rule-content-type/README.md
+++ b/packages/rule-content-type/README.md
@@ -171,22 +171,10 @@ header, and thus, make your web site/app pass this rule.
 
   # Data interchange
 
-    # 2.2.x+
-
+    AddType application/json                            map
     AddType text/xml                                    xml
 
-    # 2.2.x - 2.4.x
-
-    AddType application/json                            json
-    AddType application/rss+xml                         rss
-
-    # 2.4.x+
-
-    AddType application/json                            map
-
   # JavaScript
-
-    # 2.2.x+
 
     # See: https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages.
     AddType text/javascript                             js mjs
@@ -194,51 +182,27 @@ header, and thus, make your web site/app pass this rule.
 
   # Manifest files
 
-    # 2.2.x+
-
     AddType application/manifest+json                   webmanifest
     AddType text/cache-manifest                         appcache
 
 
   # Media files
 
-    # 2.2.x - 2.4.x
-
-    AddType audio/mp4                                   f4a f4b m4a
-    AddType audio/ogg                                   oga ogg spx
-    AddType video/mp4                                   mp4 mp4v mpg4
-    AddType video/ogg                                   ogv
-    AddType video/webm                                  webm
-    AddType video/x-flv                                 flv
-
-    # 2.2.x+
-
     AddType image/svg+xml                               svgz
-    AddType image/x-icon                                cur
-
-    # 2.4.x+
-
     AddType image/webp                                  webp
+    AddType image/x-icon                                cur
 
 
   # Web fonts
 
-    # 2.2.x - 2.4.x
-
-    AddType application/vnd.ms-fontobject               eot
-
-    # 2.2.x+
-
-    AddType font/woff                                   woff
-    AddType font/woff2                                  woff2
-    AddType font/ttf                                    ttf
     AddType font/collection                             ttc
     AddType font/otf                                    otf
+    AddType font/ttf                                    ttf
+    AddType font/woff                                   woff
+    AddType font/woff2                                  woff2
 
 
   # Other
-
-    # 2.2.x+
 
     AddType text/vtt                                    vtt
 
@@ -279,7 +243,7 @@ AddDefaultCharset utf-8
 
 Note that:
 
-* The above snippet works with Apache `v2.2.0+`, but you need to have
+* The above snippet works with Apache `v2.4.0+`, but you need to have
   [`mod_mime`][mod_mime] [enabled][how to enable apache modules]
   in order for it to take effect.
 

--- a/packages/rule-highest-available-document-mode/README.md
+++ b/packages/rule-highest-available-document-mode/README.md
@@ -293,7 +293,7 @@ level, using the following:
 
 Note that:
 
-* The above snippets work with Apache `v2.2.0+`, but you need to have
+* The above snippets work with Apache `v2.4.0+`, but you need to have
   [`mod_headers`][mod_headers] [enabled][how to enable apache modules]
   in order for them to take effect.
 

--- a/packages/rule-http-cache/README.md
+++ b/packages/rule-http-cache/README.md
@@ -287,7 +287,7 @@ Important notes:
 
 Also note that:
 
-* The above snippet works with Apache `v2.2.0+`, but you need to
+* The above snippet works with Apache `v2.4.0+`, but you need to
   have [`mod_expires`][mod_expires] and [`mod_headers`][mod_headers]
   [enabled][how to enable apache modules]
   in order for it to take effect.

--- a/packages/rule-http-compression/README.md
+++ b/packages/rule-http-compression/README.md
@@ -750,38 +750,29 @@ Important notes:
 <IfModule mod_deflate.c>
 
     # 3) gzip
-    #
-    # [!] For Apache versions below version 2.3.7 you don't need to
-    # enable `mod_filter` and can remove the `<IfModule mod_filter.c>`
-    # and `</IfModule>` lines as `AddOutputFilterByType` is still in
-    # the core directives.
-    #
-    # https://httpd.apache.org/docs/current/mod/mod_filter.html#addoutputfilterbytype
 
-    <IfModule mod_filter.c>
-        AddOutputFilterByType DEFLATE "application/atom+xml" \
-                                      "application/json" \
-                                      "application/manifest+json" \
-                                      "application/rdf+xml" \
-                                      "application/rss+xml" \
-                                      "application/schema+json" \
-                                      "application/vnd.ms-fontobject" \
-                                      "application/xhtml+xml" \
-                                      "font/collection" \
-                                      "font/opentype" \
-                                      "font/otf" \
-                                      "font/ttf" \
-                                      "image/bmp" \
-                                      "image/svg+xml" \
-                                      "image/x-icon" \
-                                      "text/cache-manifest" \
-                                      "text/css" \
-                                      "text/html" \
-                                      "text/javascript" \
-                                      "text/plain" \
-                                      "text/vtt" \
-                                      "text/xml"
-    </IfModule>
+    AddOutputFilterByType DEFLATE "application/atom+xml" \
+                                  "application/json" \
+                                  "application/manifest+json" \
+                                  "application/rdf+xml" \
+                                  "application/rss+xml" \
+                                  "application/schema+json" \
+                                  "application/vnd.ms-fontobject" \
+                                  "application/xhtml+xml" \
+                                  "font/collection" \
+                                  "font/opentype" \
+                                  "font/otf" \
+                                  "font/ttf" \
+                                  "image/bmp" \
+                                  "image/svg+xml" \
+                                  "image/x-icon" \
+                                  "text/cache-manifest" \
+                                  "text/css" \
+                                  "text/html" \
+                                  "text/javascript" \
+                                  "text/plain" \
+                                  "text/vtt" \
+                                  "text/xml"
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -801,10 +792,9 @@ Important notes:
 
 Also note that:
 
-* The above snippet works with Apache `v2.2.0+`, but you need to
-  have [`mod_deflate`][mod_deflate], [`mod_mime`][mod_mime],
-  [`mod_rewrite`][mod_rewrite], and for Apache versions below
-  `v2.3.7` [`mod_filter`][mod_filter] [enabled][how to enable apache
+* The above snippet works with Apache `v2.4.0+`, but you need to
+  have [`mod_deflate`][mod_deflate], and [`mod_mime`][mod_mime],
+  [`mod_rewrite`][mod_rewrite] [enabled][how to enable apache
   modules] in order for it to take effect.
 
 * If you have access to the [main Apache configuration file][main

--- a/packages/rule-no-disallowed-headers/README.md
+++ b/packages/rule-no-disallowed-headers/README.md
@@ -155,7 +155,7 @@ ServerTokens Prod
 
 Note that:
 
-* The above snippets works with Apache `v2.2.0+`, but you need to have
+* The above snippets works with Apache `v2.4.0+`, but you need to have
   [`mod_headers`][mod_headers] [enabled][how to enable apache modules]
   in order for them to take effect.
 

--- a/packages/rule-no-html-only-headers/README.md
+++ b/packages/rule-no-html-only-headers/README.md
@@ -140,7 +140,7 @@ you can do something such as the following:
 
 Note that:
 
-* The above snippet works with Apache `v2.2.0+`, but you need to have
+* The above snippet works with Apache `v2.4.0+`, but you need to have
   [`mod_headers`][mod_headers] [enabled][how to enable apache modules]
   in order for it to take effect.
 

--- a/packages/rule-strict-transport-security/README.md
+++ b/packages/rule-strict-transport-security/README.md
@@ -160,7 +160,7 @@ using the [`Header` directive][header directive], e.g.:
 
 Note that:
 
-* The above snippet works with Apache `v2.2.0+`, but you need to have
+* The above snippet works with Apache `v2.4.0+`, but you need to have
   [`mod_headers`][mod_headers] [enabled][how to enable apache modules]
   in order for it to take effect.
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

From https://httpd.apache.org/#apache-httpd-22-end-of-life-2018-01-01:

    Apache httpd 2.2 End-of-Life 2018-01-01

    As previously announced, the Apache HTTP Server Project has
    discontinued all development and patch review of the 2.2.x
    series of releases.

    The Apache HTTP Server Project had long committed to provide
    maintenance releases of the 2.2.x flavor through June of 2017,
    and to continue to publish some security source code patches
    until December of 2017. The final release 2.2.34 was published
    in July 2017, and no further evaluation of security risks will
    be published for 2.2.x releases.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #975
