### PR TITLE
Docs: fix spelling error on configurations page

### DIFF
--- a/packages/sonarwhal/docs/user-guide/concepts/configurations.md
+++ b/packages/sonarwhal/docs/user-guide/concepts/configurations.md
@@ -14,7 +14,7 @@ To use a `configuration`, you have to:
    `--init`, the wizard will list you the official configuration packages but
    you can search on `npm`. Any package `@sonarwhal/configuration-` or
    `sonarwhal-configuration-` should be a valid candidate.
-2. Once installed, update your `.sonarwhalrc` to use it (this step is no needed
+2. Once installed, update your `.sonarwhalrc` to use it (this step is not needed
    if you are using the wizard):
 
 ```json


### PR DESCRIPTION
Fixed spelling error located in step 2 of https://sonarwhal.com/docs/user-guide/concepts/configurations/ 

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x ] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x ] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->