### PR TITLE
Fix: Use correct type definition in JSON schema

### DIFF
--- a/packages/rule-http-cache/src/rule.ts
+++ b/packages/rule-http-cache/src/rule.ts
@@ -40,8 +40,8 @@ export default class HttpCacheRule implements IRule {
                 }
             },
             properties: {
-                maxAgeResource: 'number',
-                maxAgeTarget: 'number',
+                maxAgeResource: { type: 'number' },
+                maxAgeTarget: { type: 'number' },
                 revvingPatterns: { $ref: '#/definitions/string-array' }
             }
         }],


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->

The schema validation of the http-cache rule does currently cause an error: 

```text
Error: schema is invalid: data.properties['maxAgeResource'] should be object,boolean, data.properties['maxAgeTarget'] should be object,boolean
```

This is because the JSON schema for that rule is currently not parsable. This pull request will fix that.