### PR TITLE
Chore: Remove `.yarnrc` file

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-workspaces-experimental true


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Yarn's workspaces feature is now (and has been for quite some time) enabled by default.

From https://yarnpkg.com/lang/en/docs/workspaces/#toc--tricks:

 > Workspaces are stable enough to be used in large-scale applications
   and shouldn’t change anything to the way the regular installs work,
   but if you think they’re breaking something, you can disable them
   by adding the following line into your Yarnrc file
>
>   `workspaces-experimental false` 

See also: https://github.com/yarnpkg/yarn/commit/d39a2e85c13ff61f5785e071ac73aed1aa037640

