### PR TITLE
Fix: Improve output on Windows machines

### DIFF
--- a/packages/formatter-codeframe/package.json
+++ b/packages/formatter-codeframe/package.json
@@ -12,6 +12,7 @@
     "lodash.foreach": "^4.5.0",
     "lodash.groupby": "^4.6.0",
     "lodash.sortby": "^4.7.0",
+    "log-symbols": "^2.2.0",
     "pluralize": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/formatter-codeframe/src/formatter.ts
+++ b/packages/formatter-codeframe/src/formatter.ts
@@ -16,6 +16,7 @@ import * as groupBy from 'lodash.groupby';
 import * as sortBy from 'lodash.sortby';
 import * as forEach from 'lodash.foreach';
 import * as pluralize from 'pluralize';
+import * as logSymbols from 'log-symbols';
 
 import { cutString } from 'sonarwhal/dist/src/lib/utils/misc';
 import { debug as d } from 'sonarwhal/dist/src/lib/utils/debug';
@@ -159,6 +160,6 @@ export default class CodeframeFormatter implements IFormatter {
 
         const color: typeof chalk = totalErrors > 0 ? chalk.red : chalk.yellow;
 
-        logger.log(color.bold(`\u2716 Found a total of ${totalErrors} ${pluralize('error', totalErrors)} and ${totalWarnings} ${pluralize('warning', totalWarnings)}`));
+        logger.log(color.bold(`${logSymbols.error} Found a total of ${totalErrors} ${pluralize('error', totalErrors)} and ${totalWarnings} ${pluralize('warning', totalWarnings)}`));
     }
 }

--- a/packages/formatter-stylish/package.json
+++ b/packages/formatter-stylish/package.json
@@ -12,6 +12,7 @@
     "lodash.foreach": "^4.5.0",
     "lodash.groupby": "^4.6.0",
     "lodash.sortby": "^4.7.0",
+    "log-symbols": "^2.2.0",
     "pluralize": "^7.0.0",
     "text-table": "^0.2.0"
   },

--- a/packages/formatter-stylish/src/formatter.ts
+++ b/packages/formatter-stylish/src/formatter.ts
@@ -16,6 +16,7 @@ import * as groupBy from 'lodash.groupby';
 import * as sortBy from 'lodash.sortby';
 import * as table from 'text-table';
 import * as pluralize from 'pluralize';
+import * as logSymbols from 'log-symbols';
 
 import { cutString } from 'sonarwhal/dist/src/lib/utils/misc';
 import { debug as d } from 'sonarwhal/dist/src/lib/utils/debug';
@@ -102,12 +103,12 @@ export default class StylishFormatter implements IFormatter {
             totalErrors += errors;
             totalWarnings += warnings;
 
-            logger.log(color.bold(`\u2716 Found ${errors} ${pluralize('error', errors)} and ${warnings} ${pluralize('warning', warnings)}`));
+            logger.log(color.bold(`${logSymbols.error} Found ${errors} ${pluralize('error', errors)} and ${warnings} ${pluralize('warning', warnings)}`));
             logger.log('');
         });
 
         const color: typeof chalk = totalErrors > 0 ? chalk.red : chalk.yellow;
 
-        logger.log(color.bold(`\u2716 Found a total of ${totalErrors} ${pluralize('error', totalErrors)} and ${totalWarnings} ${pluralize('warning', totalWarnings)}`));
+        logger.log(color.bold(`${logSymbols.error} Found a total of ${totalErrors} ${pluralize('error', totalErrors)} and ${totalWarnings} ${pluralize('warning', totalWarnings)}`));
     }
 }

--- a/packages/formatter-stylish/tests/tests.ts
+++ b/packages/formatter-stylish/tests/tests.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import * as sinon from 'sinon';
 import * as proxyquire from 'proxyquire';
 import * as table from 'text-table';
+import * as logSymbols from 'log-symbols';
 
 const logging = { log() { } };
 
@@ -48,7 +49,7 @@ test(`Stylish formatter prints a table and a summary for each resource`, (t) => 
 
     t.is(log.args[0][0], chalk.cyan('http://myresource.com/'));
     t.is(log.args[1][0], tableString);
-    t.is(log.args[2][0], chalk.yellow.bold(`\u2716 Found 0 errors and 3 warnings`));
+    t.is(log.args[2][0], chalk.yellow.bold(`${logSymbols.error} Found 0 errors and 3 warnings`));
     t.is(log.args[3][0], '');
     t.is(log.args[4][0], chalk.cyan('http://myresource2.com/this/resource/i … /resources/image/imagewithalongname.jpg'));
 
@@ -60,6 +61,6 @@ test(`Stylish formatter prints a table and a summary for each resource`, (t) => 
     tableString = table(tableData);
 
     t.is(log.args[5][0], tableString);
-    t.is(log.args[6][0], chalk.red.bold(`\u2716 Found 1 error and 1 warning`));
+    t.is(log.args[6][0], chalk.red.bold(`${logSymbols.error} Found 1 error and 1 warning`));
     t.is(log.args[7][0], '');
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [X] Added/Updated related tests.

## Short description of the change(s)

The output on windows not always had ❌ in all formatters. This fixes this.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
