### PR TITLE
New: Rules via cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To use a different rule than the one specified in your `.sonarwhalrc` file:
 ```bash
 sonarwhal https://example.com --rules html-checker
 ```
+
 For more in depth information on how to get started, configurations,
 and more, see the online [user guide](https://sonarwhal.com/docs/user-guide/),
 or the [local version](./packages/sonarwhal/docs/user-guide/index.md)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ To use a different rule than the one specified in your `.sonarwhalrc` file:
 sonarwhal https://example.com --rules html-checker
 ```
 
+Multiple rules can be specified as a comma sepreated string:
+
+```bash
+sonarwhal https://example.com --rules axe,html-checker
+```
+
 For more in depth information on how to get started, configurations,
 and more, see the online [user guide](https://sonarwhal.com/docs/user-guide/),
 or the [local version](./packages/sonarwhal/docs/user-guide/index.md)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ To use a different formatter than the one specified in your `.sonarwhalrc` file
 sonarwhal https://example.com --formatters excel
 ```
 
+To use a different rule than the one specified in your `.sonarwhalrc` file:
+
+```bash
+sonarwhal https://example.com --rules html-checker
+```
 For more in depth information on how to get started, configurations,
 and more, see the online [user guide](https://sonarwhal.com/docs/user-guide/),
 or the [local version](./packages/sonarwhal/docs/user-guide/index.md)

--- a/packages/sonarwhal/src/lib/cli/options.ts
+++ b/packages/sonarwhal/src/lib/cli/options.ts
@@ -77,6 +77,12 @@ export const options = optionator({
             description: 'Explicitly specify the formatters to be used',
             option: 'formatters',
             type: 'String'
+        },
+        {
+            alias: 'r',
+            description: 'Explicitly specify the rules to be used',
+            option: 'rules',
+            type: 'String'
         }
     ],
     prepend: 'sonarwhal [options] https://url.com'

--- a/packages/sonarwhal/src/lib/config.ts
+++ b/packages/sonarwhal/src/lib/config.ts
@@ -145,9 +145,9 @@ const updateConfigWithCommandLineValues = (config: UserConfig, actions: CLIOptio
 
     // If rules are provided, use them
     if (actions && actions.rules) {
-        const rulesarray = actions.rules.split(',');
+        const ruleNames = actions.rules.split(',');
 
-        config.rules = buildRulesConfigFromRuleNames(rulesarray, 'warning');
+        config.rules = buildRulesConfigFromRuleNames(ruleNames, 'warning');
         debug(`Using rules option provided from command line: ${actions.rules}`);
     }
 };

--- a/packages/sonarwhal/src/lib/config.ts
+++ b/packages/sonarwhal/src/lib/config.ts
@@ -147,7 +147,7 @@ const updateConfigWithCommandLineValues = (config: UserConfig, actions: CLIOptio
     if (actions && actions.rules) {
         const ruleNames = actions.rules.split(',');
 
-        config.rules = buildRulesConfigFromRuleNames(ruleNames, 'warning');
+        config.rules = buildRulesConfigFromRuleNames(ruleNames, 'error');
         debug(`Using rules option provided from command line: ${actions.rules}`);
     }
 };

--- a/packages/sonarwhal/src/lib/config.ts
+++ b/packages/sonarwhal/src/lib/config.ts
@@ -119,6 +119,19 @@ const loadIgnoredUrls = (userConfig: UserConfig): Map<string, RegExp[]> => {
 };
 
 /**
+ * Build and return a rules config object where the key is the rule name and the value is the severity
+ */
+const buildRulesConfigFromRuleNames = (ruleNames: string[], severity: string): RulesConfigObject => {
+    const ruleConfig: RulesConfigObject = {};
+
+    for (const ruleName of ruleNames) {
+        ruleConfig[ruleName] = severity;
+    }
+
+    return ruleConfig;
+};
+
+/**
  * Overrides the config values with values obtained from the CLI, if any
  */
 const updateConfigWithCommandLineValues = (config: UserConfig, actions: CLIOptions) => {
@@ -128,6 +141,14 @@ const updateConfigWithCommandLineValues = (config: UserConfig, actions: CLIOptio
     if (actions && actions.formatters) {
         config.formatters = actions.formatters.split(',');
         debug(`Using formatters option provided from command line: ${actions.formatters}`);
+    }
+
+    // If rules are provided, use them
+    if (actions && actions.rules) {
+        const rulesarray = actions.rules.split(',');
+
+        config.rules = buildRulesConfigFromRuleNames(rulesarray, 'warning');
+        debug(`Using rules option provided from command line: ${actions.rules}`);
     }
 };
 

--- a/packages/sonarwhal/src/lib/types.ts
+++ b/packages/sonarwhal/src/lib/types.ts
@@ -86,6 +86,12 @@ export type CLIOptions = {
      * For more than one formatter, use comma separated, with no spaces values. E.g.: "excel,summary"
      */
     formatters: string;
+
+    /**
+     * rule name(s) to be used. If provided this will override the config file setting value
+     * For more than one rule, use comma separated, with no spaces values. E.g.: "content-type,axe"
+     */
+    rules: string;
 };
 
 export type ORA = {

--- a/packages/sonarwhal/tests/lib/config.ts
+++ b/packages/sonarwhal/tests/lib/config.ts
@@ -303,3 +303,54 @@ test('If formatter is not specified as CLI argument, fromConfig method will use 
     t.is(result.formatters[0], 'summary');
     t.is(result.formatters[1], 'excel');
 });
+
+test('If rules option is specified as CLI argument, fromConfig method will use that to build SonarwhalConfig', (t) => {
+    const { config } = t.context;
+    const userConfig = {
+        connector: { name: 'chrome' },
+        formatters: ['summary'],
+        rules: { 'apple-touch-icons': 'warning' }
+    } as UserConfig;
+    const cliOptions = { _: ['https://example.com'], rules: 'html-checker,content-type' } as CLIOptions;
+
+    const result = config.SonarwhalConfig.fromConfig(userConfig, cliOptions);
+
+    t.is(result.rules.hasOwnProperty('html-checker'), true);
+    t.is(result.rules.hasOwnProperty('content-type'), true);
+    // Make sure we updated only the rules. Other properties of userConfig should stay same
+    t.is(result.formatters[0], 'summary');
+});
+
+test('If rules option is not specified as CLI argument, fromConfig method will use the rules specified in the userConfig object as it is to build SonarwhalConfig', (t) => {
+    const { config } = t.context;
+    const userConfig = {
+        connector: { name: 'chrome' },
+        formatters: ['summary'],
+        rules: { 'apple-touch-icons': 'warning' }
+    } as UserConfig;
+    const cliOptions = { _: ['https://example.com'] } as CLIOptions;
+
+    const result = config.SonarwhalConfig.fromConfig(userConfig, cliOptions);
+
+    t.is(result.rules.hasOwnProperty('apple-touch-icons'), true);
+});
+
+test('If both rules and formatters options are specified as CLI arguments, fromConfig method will use that to build SonarwhalConfig', (t) => {
+    const { config } = t.context;
+    const userConfig = {
+        connector: { name: 'chrome' },
+        formatters: ['summary', 'excel'],
+        rules: { 'apple-touch-icons': 'warning' }
+    } as UserConfig;
+    const cliOptions = { _: ['https://example.com'], formatters: 'database', rules: 'html-checker'} as CLIOptions;
+
+    const result = config.SonarwhalConfig.fromConfig(userConfig, cliOptions);
+
+    // verify formatters
+    t.is(result.formatters.length, 1);
+    t.is(result.formatters[0], 'database');
+
+    // verify rules
+    t.is(result.rules.hasOwnProperty('html-checker'), true);
+    t.is(result.rules.hasOwnProperty('apple-touch-icons'), false);
+});


### PR DESCRIPTION
This change will allow users to explicitly pass the rules via cmd line.

Example : `sonarwhal https://example.com --rules http-cache,html-checker`

Fix #1020

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

