### PR TITLE
Correct broken link on SSL Labs rule URL

### DIFF
--- a/packages/sonarwhal/docs/user-guide/index.md
+++ b/packages/sonarwhal/docs/user-guide/index.md
@@ -69,7 +69,7 @@ Wait a few seconds and you will get something similar to the following:
 ![Example output for the summary formatter](images/summary-output.png)
 
 It might take a few minutes to get some of the results. Some of the
-rules (e.g.: [`SSL Labs`](./rules/ssllabs.md)) can take a few minutes
+rules (e.g.: [`SSL Labs`](/rules/rule-ssllabs.md)) can take a few minutes
 to report the results.
 
 Now that you have your first result, is time to learn a bit more about


### PR DESCRIPTION
The correct page is `https://sonarwhal.com/docs/user-guide/rules/rule-ssllabs/`, not `https://sonarwhal.com/docs/user-guide/rules/ssllabs/`.

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
