### PR TITLE
Chore: Show message when binary fails to load

### DIFF
--- a/packages/sonarwhal/src/lib/utils/resource-loader.ts
+++ b/packages/sonarwhal/src/lib/utils/resource-loader.ts
@@ -147,9 +147,17 @@ export const tryToLoadFrom = (resourcePath: string): any => {
         debug(`Can't require ${resourcePath}`);
 
         if (e.code === 'MODULE_NOT_FOUND') {
+            /*
+             * This get the name of the missed module
+             * e.g: Cannot find module 'iltorb'
+             */
             const exec = moduleNameRegex.exec(e.message);
             const moduleName = exec ? exec[1] : null;
 
+            /*
+             * If the module not found is the same as the module
+             * we are trying to load, then is ok.
+             */
             if (!moduleName || moduleName === resourcePath) {
                 return null;
             }

--- a/packages/sonarwhal/src/lib/utils/resource-loader.ts
+++ b/packages/sonarwhal/src/lib/utils/resource-loader.ts
@@ -25,6 +25,7 @@ import { ResourceType } from '../enums/resourcetype';
 const debug: debug.IDebugger = d(__filename);
 const SONARWHAL_ROOT: string = findPackageRoot();
 const NODE_MODULES_ROOT: string = findNodeModulesRoot();
+const moduleNameRegex: RegExp = /[^']*'([^']*)'/g;
 
 /** Cache of resource builders, indexex by resource Id. */
 const resources: Map<string, Resource> = new Map<string, Resource>();
@@ -144,6 +145,20 @@ export const tryToLoadFrom = (resourcePath: string): any => {
         builder = resource.default || resource;
     } catch (e) {
         debug(`Can't require ${resourcePath}`);
+
+        if (e.code === 'MODULE_NOT_FOUND') {
+            const exec = moduleNameRegex.exec(e.message);
+            const moduleName = exec ? exec[1] : null;
+
+            if (!moduleName || moduleName === resourcePath) {
+                return null;
+            }
+
+            // The resourcePath and the module not found are different.
+            throw new Error(`Module ${moduleName} not found when loading ${resourcePath}`);
+        }
+
+        throw e;
     }
 
     return builder;

--- a/packages/sonarwhal/tests/lib/utils/resource-loader.ts
+++ b/packages/sonarwhal/tests/lib/utils/resource-loader.ts
@@ -19,6 +19,44 @@ const cleanCache = () => {
     delete require.cache[cacheKey];
 };
 
+test.serial('tryToLoadFrom throws an error if a dependency is missing', (t) => {
+    const Module = require('module');
+    const resourceLoader = require('../../../src/lib/utils/resource-loader');
+
+    const sandbox = sinon.createSandbox();
+
+    sandbox.stub(Module.prototype, 'require').throws({
+        code: 'MODULE_NOT_FOUND',
+        message: `Cannot load module 'iltorb'`
+    });
+
+    const { message } = t.throws(() => {
+        resourceLoader.tryToLoadFrom('sonarwhal');
+    });
+
+    t.is(message, 'Module iltorb not found when loading sonarwhal');
+
+    sandbox.restore();
+});
+
+test.serial('tryToLoadFrom does nothing if the package itself is missing', (t) => {
+    const Module = require('module');
+    const resourceLoader = require('../../../src/lib/utils/resource-loader');
+
+    const sandbox = sinon.createSandbox();
+
+    sandbox.stub(Module.prototype, 'require').throws({
+        code: 'MODULE_NOT_FOUND',
+        message: `Cannot load module 'sonarwhal'`
+    });
+
+    const resource = resourceLoader.tryToLoadFrom('sonarwhal');
+
+    t.is(resource, null);
+
+    sandbox.restore();
+});
+
 // TODO: Add tests to verify the order of loading is the right one: core -> scoped -> prefixed. This only checks core resources
 test('loadResource looks for resources in the right order (core > @sonarwhal > sonarwhal- ', (t) => {
     cleanCache();


### PR DESCRIPTION
This commit shows an error message when a resource fails
loading a dependency.

Fix #1043

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
