### PR TITLE
Docs: Fix packages URL on npmjs.org

### DIFF
--- a/packages/sonarwhal/docs/user-guide/concepts/formatters.md
+++ b/packages/sonarwhal/docs/user-guide/concepts/formatters.md
@@ -63,8 +63,8 @@ guide][contributor guide]
 <!-- Link labels: -->
 
 [contributor guide]: ../../../contributor-guide/formatters/
-[formatter-json]: https://npmjs.com/packages/@sonarwhal/formatter-json
-[formatter-stylish]: https://npmjs.com/packages/@sonarwhal/formatter-stylish
-[formatter-codeframe]: https://npmjs.com/packages/@sonarwhal/formatter-codeframe
-[formatter-summary]: https://npmjs.com/packages/@sonarwhal/formatter-summary
-[formatter-excel]: https://npmjs.com/packages/@sonarwhal/formatter-excel
+[formatter-json]: https://npmjs.com/package/@sonarwhal/formatter-json
+[formatter-stylish]: https://npmjs.com/package/@sonarwhal/formatter-stylish
+[formatter-codeframe]: https://npmjs.com/package/@sonarwhal/formatter-codeframe
+[formatter-summary]: https://npmjs.com/package/@sonarwhal/formatter-summary
+[formatter-excel]: https://npmjs.com/package/@sonarwhal/formatter-excel


### PR DESCRIPTION
Links to formatter packages on npmjs.org are currently leading to 404. :/
Doest this PR need a build or something?



## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

