### PR TITLE
Revving regex

### DIFF
--- a/packages/rule-http-cache/README.md
+++ b/packages/rule-http-cache/README.md
@@ -34,20 +34,36 @@ validate that the page and resources have a good caching strategy:
     one based on query string parameters (see: [problems with
     proxys][revving files])
 
-The built-in regular expression for file revving is:
+The built-in regular expressions for file revving are:
 
 ```regexp
-/\/(\w|-|_)+(\.|-|_)\w+\.\w+$/i
+/\/[^/]+[._-]v?\d+(\.\d+(\.\d+)?)?[^/]*\.\w+$/i
+/\/v?\d+\.\d+\.\d+.*?\//i
+/\/\d+\//
+/\/v\d.*?\//i
+/\/([^/]+[._-])?([0-9a-f]{5,})([._-].*?)?\.\w+$/i
 ```
 
-This will match urls like the following:
+This will match URLs like the following:
 
 ```text
-https://example.com/assets/script.13b55av.js
-https://example.com/assets/script-2.13b55av.js
-https://example.com/assets/script_2-13b55av.js
-https://example.com/assets/sw_script_13b553442.js
+https://example.com/assets/jquery-2.1.1.js
+https://example.com/assets/jquery-2.1.1.min.js
+https://example.com/assets/jquery-3.0.0-beta.js
+https://example.com/assets/favicon.123.ico
+https://example.com/wp-content/uploads/fvm/out/header-cb050ccd-1524626949.min.js
+https://cdn.example.com/jquery.lazy/1.6.5/jquery.lazy.min.js
+https://s3.amazonaws.com/example/wp-content/uploads/2017/07/15084048/jquery.mediaBoxes.dropdown.js
+https://example.com/site/javascript/v5/jquery.cookie.js
+https://static.xx.fbcdn.net/rsrc.php/v3iJhv4/yG/l/en_US/sqNNamBywvN.js
+https://example.com/assets/unicorn-d41d8cd98f.css
+https://example.com/assets/app.e1c7a.bundle.js
+https://example.com/assets/9f61f58dd1cc3bb82182.bundle.js
+https://example.com/assets/9f61f.js
+https://example.com/assets/9f61f.min.js
 ```
+
+[Test your URLs](https://regex101.com/r/6VduJO/36/)
 
 ### Examples that **trigger** the rule
 

--- a/packages/rule-http-cache/src/rule.ts
+++ b/packages/rule-http-cache/src/rule.ts
@@ -90,15 +90,44 @@ export default class HttpCacheRule implements IRule {
         /** The predefined patterns for file revving.*/
         const predefinedRevvingPatterns: Array<RegExp> = [
             /*
-             * E.g.:
-             * - https://example.com/assets/script.12345.js
-             * - https://example.com/assets/script-2.12345.js
-             * - https://example.com/assets/script_2-12345.js
-             * - https://example.com/assets/icon_meca_1473335663.svg
+             * E.g.: version/timestamp/hash
              *
-             * Live example: https://regex101.com/r/6VduJO/2/
+             * Live example: https://regex101.com/r/6VduJO/36/
              */
-            /\/(\w|-|_)+(\.|-|_)\w+\.\w+$/i
+
+            /*
+             * - https://example.com/assets/jquery-2.1.1.js
+             * - https://example.com/assets/jquery-2.1.1.min.js
+             * - https://example.com/assets/jquery-3.0.0-beta.js
+             * - https://example.com/assets/favicon.123.ico
+             * - https://example.com/wp-content/uploads/fvm/out/header-cb050ccd-1524626949.min.js
+             */
+            /\/[^/]+[._-]v?\d+(\.\d+(\.\d+)?)?[^/]*\.\w+$/i,
+
+            /*
+             * - https://cdn.example.com/jquery.lazy/1.6.5/jquery.lazy.min.js
+             */
+            /\/v?\d+\.\d+\.\d+.*?\//i,
+
+            /*
+             * - https://s3.amazonaws.com/example/wp-content/uploads/2017/07/15084048/jquery.mediaBoxes.dropdown.js
+             */
+            /\/\d+\//,
+
+            /*
+             * - https://example.com/site/javascript/v5/jquery.cookie.js
+             * - https://static.xx.fbcdn.net/rsrc.php/v3iJhv4/yG/l/en_US/sqNNamBywvN.js
+             */
+            /\/v\d.*?\//i,
+
+            /*
+             * - https://example.com/assets/unicorn-d41d8cd98f.css
+             * - https://example.com/assets/app.e1c7a.bundle.js
+             * - https://example.com/assets/9f61f58dd1cc3bb82182.bundle.js
+             * - https://example.com/assets/9f61f.js
+             * - https://example.com/assets/9f61f.min.js
+             */
+            /\/([^/]+[._-])?([0-9a-f]{5,})([._-].*?)?\.\w+$/i
         ];
 
         /** The cache revving patterns to use for matching.*/

--- a/packages/rule-http-cache/tests/tests.ts
+++ b/packages/rule-http-cache/tests/tests.ts
@@ -254,6 +254,90 @@ const defaultTests: Array<RuleTest> = [
         }
     },
     {
+        name: 'JS with long max-age, immutable and file revving with multiple dots passes',
+        serverConfig: {
+            '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/js.script.123.js"></script>'),
+            '/favicon.123.ico': {
+                content: '',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            },
+            '/js.script.123.js': {
+                content: 'var a = 10;',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            }
+        }
+    },
+    {
+        name: 'JS with long max-age, immutable and file revving with semver passes',
+        serverConfig: {
+            '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/jquery-2.1.1.min.js"></script>'),
+            '/favicon.123.ico': {
+                content: '',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            },
+            '/jquery-2.1.1.min.js': {
+                content: 'var a = 10;',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            }
+        }
+    },
+    {
+        name: 'JS with long max-age, immutable and file revving with last modified timestamp passes',
+        serverConfig: {
+            '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/js.script-1234567890.js"></script>'),
+            '/favicon.123.ico': {
+                content: '',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            },
+            '/js.script-1234567890.js': {
+                content: 'var a = 10;',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            }
+        }
+    },
+    {
+        name: 'JS with long max-age, immutable and file revving with file hash passes',
+        serverConfig: {
+            '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/unicorn-d41d8cd98f.css"></script>'),
+            '/favicon.123.ico': {
+                content: '',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            },
+            '/unicorn-d41d8cd98f.css': {
+                content: 'a { color: yellow; }',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            }
+        }
+    },
+    {
+        name: 'JS with long max-age, immutable and file revving with file hash at the beginning passes',
+        serverConfig: {
+            '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/9f61f58dd1cc3bb82182.bundle.js"></script>'),
+            '/9f61f58dd1cc3bb82182.bundle.js': {
+                content: 'var a = 10;',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            },
+            '/favicon.123.ico': {
+                content: '',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            }
+        }
+    },
+    {
+        name: 'JS with long max-age, immutable and file revving with facebook static passes',
+        serverConfig: {
+            '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/rsrc.php/v3iJhv4/yG/l/en_US/sqNNamBywvN.js"></script>'),
+            '/favicon.123.ico': {
+                content: '',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            },
+            '/rsrc.php/v3iJhv4/yG/l/en_US/sqNNamBywvN.js': {
+                content: 'var a = 10;',
+                headers: { 'Cache-Control': 'max-age=31536000, immutable' }
+            }
+        }
+    },
+    {
         name: 'JS with long max-age, immutable and file revving with `_` passes',
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon_123.ico"><script src="/script_123.js"></script>'),


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messagess)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Updated the [file revving regex](https://sonarwhal.com/docs/user-guide/rules/rule-http-cache/#what-does-the-rule-check) from:

```js
/\/(\w|-|_)+(\.|-|_)\w+\.\w+$/i
```

to: 

```js
/\/.+[._-]\w+\.\w+$/i
```

This will allow file names like `jquery.plugin.123.js` to pass the http-cache filename revving check

Fixes #1080
