### PR TITLE
Docs: Move `hot to use this rule` right before `futher reading`

### DIFF
--- a/packages/rule-amp-validator/README.md
+++ b/packages/rule-amp-validator/README.md
@@ -13,6 +13,33 @@ AMP page will load (quickly) in any modern browser.
 If you are building an AMP page, you need to make sure the HTML is valid.
 Only valid AMP content can be added to an [AMP Cache][amp-cache].
 
+## What does the rule check?
+
+This rule uses [amphtml-validator][amphtml-validator] to validate the
+HTML of your page.
+
+## Can the rule be configured?
+
+Yes, you can decide if you want to receive errors only, or also
+warnings found by [`amphtml-validator`][amphtml-validator].
+By default all warnings and errors are reported. If you prefer to
+see only the errors you can use the following rule configuration
+in your [`.sonarwhalrc`][sonarwhalrc] file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "rules": {
+        "amp-validator": ["error", {
+            "errorsOnly": true
+        }],
+        ...
+    },
+    ...
+}
+```
+
 ## How to use this rule?
 
 To use it you will have to install it via `npm`:
@@ -36,33 +63,6 @@ configuration file:
     "parsers": [...],
     "rules": {
         "amp-validator": "error"
-    },
-    ...
-}
-```
-
-## What does the rule check?
-
-This rule uses [amphtml-validator][amphtml-validator] to validate the
-HTML of your page.
-
-## Can the rule be configured?
-
-Yes, you can decide if you want to receive errors only, or also
-warnings found by [`amphtml-validator`][amphtml-validator].
-By default all warnings and errors are reported. If you prefer to
-see only the errors you can use the following rule configuration
-in your [`.sonarwhalrc`][sonarwhalrc] file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "rules": {
-        "amp-validator": ["error", {
-            "errorsOnly": true
-        }],
-        ...
     },
     ...
 }

--- a/packages/rule-apple-touch-icons/README.md
+++ b/packages/rule-apple-touch-icons/README.md
@@ -72,34 +72,6 @@ Other notes:
   in which the icons were declared mattered][icon sizes]. When using
   one image there is no need to use the `sizes` attribute.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-apple-touch-icons
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "apple-touch-icons": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks if a single `apple-touch-icon` declaration exists in
@@ -231,6 +203,34 @@ apple-touch-icon.png: PNG image data, 180 x 180, ...
     </head>
     <body>...</body>
 </html>
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-apple-touch-icons
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "apple-touch-icons": "error"
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/rule-axe/README.md
+++ b/packages/rule-axe/README.md
@@ -29,34 +29,6 @@ accessibility is required by laws and policies in some cases.
 
 ***From [WAI’s Introduction to Web Accessibility][wai].***
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-axe
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "axe": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 By default this rule runs all the [WCAG 2.0][wcag 2.0] Level A and
@@ -126,6 +98,34 @@ Run all enabled rules except for a list of rules:
             }
         }],
         ...
+    },
+    ...
+}
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-axe
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "axe": "error"
     },
     ...
 }

--- a/packages/rule-babel-config/README.md
+++ b/packages/rule-babel-config/README.md
@@ -3,6 +3,16 @@
 `babel-config` contains rules to check if your Babel configuration has
 the most recommended configuration.
 
+## Why is this important?
+
+Babel needs to be properly configured to reflect user's preference.
+
+## Rules
+
+* [babel-config/is-valid][is-valid]
+
+## How to use this rule?
+
 To use it you will have to install it via `npm`:
 
 ```bash
@@ -28,14 +38,6 @@ configuration file:
     ...
 }
 ```
-
-## Why is this important?
-
-Babel needs to be properly configured to reflect user's preference.
-
-## Rules
-
-* [babel-config/is-valid][is-valid]
 
 ## Further Reading
 

--- a/packages/rule-content-type/README.md
+++ b/packages/rule-content-type/README.md
@@ -20,34 +20,6 @@ charset for the response as, among other:
   thus creating a bad user experience (see also:
   [`meta-charset-utf-8` rule](../rule-meta-charset-utf-8))
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-content-type
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "content-type": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks if responses include the `Content-Type` HTTP response
@@ -443,6 +415,34 @@ In the [`.sonarwhalrc`][sonarwhalrc] file:
 Note: You can also use the [`ignoredUrls`](../index.md#rule-configuration)
 property from the `.sonarwhalrc` file to exclude domains you don’t control
 (e.g.: CDNs) from these checks.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-content-type
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "content-type": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-disown-opener/README.md
+++ b/packages/rule-disown-opener/README.md
@@ -69,34 +69,6 @@ Notes:
   property] property that will prevent the `window.opener` reference
   from being set.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-disown-opener
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "disown-opener": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 By default, the rule checks if the `rel` attribute was specified with
@@ -202,6 +174,34 @@ Also, note that this rule takes into consideration the [targeted
 browsers](../index.md#browser-configuration), and if all of them
 support the `noopener` value, the rule won’t require the `noreferrer`
 value.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-disown-opener
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "disown-opener": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-highest-available-document-mode/README.md
+++ b/packages/rule-highest-available-document-mode/README.md
@@ -44,34 +44,6 @@ Notes:
   the meta tag is not recommended as [`Chrome Frame` has been
   deprecated][chrome frame] for quite some time.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-highest-available-document-mode
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "highest-available-document-mode": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 By default the rule checks if the `X-UA-Compatible` response header is
@@ -391,6 +363,34 @@ Also, note that this rule takes into consideration the [targeted
 browsers][targeted browsers], and if Internet Explorer 8/9/10 aren’t
 among them, it will suggest removing the `meta` tag or/and not sending
 the HTTP response header.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-highest-available-document-mode
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "highest-available-document-mode": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-html-checker/README.md
+++ b/packages/rule-html-checker/README.md
@@ -21,34 +21,6 @@
 This rule interacts with this service via [`html-validator`][html-validator],
 and is able to test both remote websites and local server instances.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-html-checker
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "html-checker": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 According to the Nu Html checker [documentation][nu html checker docs],
@@ -144,6 +116,34 @@ alternative validator exposes the same REST interface as the default one.
             "validator": "https://html5.validator.nu"
         }],
         ...
+    },
+    ...
+}
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-html-checker
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "html-checker": "error"
     },
     ...
 }

--- a/packages/rule-http-cache/README.md
+++ b/packages/rule-http-cache/README.md
@@ -19,34 +19,6 @@ their configuration:
 
 [Source: http archive][maxage0]
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-http-cache
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "http-cache": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule checks the configuration of the `cache-control` header to
@@ -401,6 +373,34 @@ one:
 ```text
 https://example.com/assets/12345/script.js
 https://example.com/assets/12345/styles.css
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-http-cache
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "http-cache": "error"
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/rule-http-compression/README.md
+++ b/packages/rule-http-compression/README.md
@@ -95,34 +95,6 @@ resources:
   `Content-Encoding: gzip` header will create problems as user agents
   will not know they need to decompress before trying to display them.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-http-compression
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "http-compression": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks for the use cases previously specified, namely, it
@@ -1052,6 +1024,34 @@ use the following configuration in the [`.sonarwhalrc`][sonarwhalrc]:
 Note: You can also use the [`ignoredUrls`](../index.md#rule-configuration)
 property from the `.sonarwhalrc` file to exclude domains you don’t control
 (e.g.: CDNs) from these checks.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-http-compression
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "http-compression": "error"
+    },
+    ...
+}
+```
 
 <!-- Link labels: -->
 

--- a/packages/rule-https-only/README.md
+++ b/packages/rule-https-only/README.md
@@ -13,35 +13,6 @@ use your users CPU power).
 Also [certain browser features][certain features] are only available if the
 site is on HTTPS.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-https-only
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "https-only": "error",
-        ...
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule checks two things:
@@ -77,6 +48,35 @@ Your site is served using HTTPS and its resources too.
     <img src="https://example.com/image.png" />
     <script src="https://example.com/script.js"></script>
 </body>
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-https-only
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "https-only": "error",
+        ...
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/rule-image-optimization-cloudinary/README.md
+++ b/packages/rule-image-optimization-cloudinary/README.md
@@ -20,34 +20,6 @@ or 1,810kB.
 By having your images optimized, you will help your users have a better
 and faster experience when navigating in your website.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-image-optimization-cloudinary
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "image-optimization-cloudinary": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule will use Cloudinary’s infrastructure to upload any images
@@ -114,6 +86,34 @@ total possible savings.
 * Having all your images optimized.
 * Having a `threshold` configured and the combined savings of all images
   smaller to that value.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-image-optimization-cloudinary
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "image-optimization-cloudinary": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-manifest-app-name/README.md
+++ b/packages/rule-manifest-app-name/README.md
@@ -49,34 +49,6 @@ Notes:
   * [Android][android] and [iOS][ios] also recommend the application
     name be under 30 characters.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-manifest-app-name
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "manifest-app-name": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks if a non-empty `name` member was specified and it’s
@@ -142,6 +114,34 @@ and a `short_name` shorter than 12 characters:
 Note: [Not specifying a manifest file](manifest-exists.md), or having
 an invalid one are covered by other rules, so those cases won’t make
 this rule fail.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-manifest-app-name
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "manifest-app-name": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-manifest-exists/README.md
+++ b/packages/rule-manifest-exists/README.md
@@ -18,34 +18,6 @@ to put metadata about your web application, and providing it:
   [opera][opera], [samsung internet][samsung internet]) in deciding if
   they will show the add to homescreen prompt to users
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-manifest-exists
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "manifest-exists": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule checks if:
@@ -143,6 +115,34 @@ More than one web app manifest file is specified:
     </head>
     <body>...</body>
 </html>
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-manifest-exists
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "manifest-exists": "error"
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/rule-manifest-file-extension/README.md
+++ b/packages/rule-manifest-file-extension/README.md
@@ -13,6 +13,27 @@ it makes it:
   the web app manifest file
 * possible to benefit from [existing configurations][other configs]
 
+## What does the rule check?
+
+The rule checks if the recommended [`.webmanifest`][file extension]
+file extension is used for the web app manifest file.
+
+### Examples that **trigger** the rule
+
+```html
+<link rel="manifest" href="site.json">
+```
+
+```html
+<link rel="manifest" href="site.manifest">
+```
+
+### Examples that **pass** the rule
+
+```html
+<link rel="manifest" href="site.webmanifest">
+```
+
 ## How to use this rule?
 
 To use it you will have to install it via `npm`:
@@ -39,27 +60,6 @@ configuration file:
     },
     ...
 }
-```
-
-## What does the rule check?
-
-The rule checks if the recommended [`.webmanifest`][file extension]
-file extension is used for the web app manifest file.
-
-### Examples that **trigger** the rule
-
-```html
-<link rel="manifest" href="site.json">
-```
-
-```html
-<link rel="manifest" href="site.manifest">
-```
-
-### Examples that **pass** the rule
-
-```html
-<link rel="manifest" href="site.webmanifest">
 ```
 
 ## Further Reading

--- a/packages/rule-manifest-is-valid/README.md
+++ b/packages/rule-manifest-is-valid/README.md
@@ -14,34 +14,6 @@ Also, providing property values that are only supported by certain
 user agents for which the [specification][manifest spec] does not define
 a fallback, can lead to interoperability issues.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-manifest-is-valid
-```
-
-Note: You can make `npm` install it as a `devDependency` using the
-`--save-dev` parameter, or to install it globally, you can use the
-`-g` parameter. For other options see [`npm`'s
-documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "manifest-is-valid": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 `manifest-is-valid` checks if:
@@ -142,6 +114,34 @@ according to the specification, and the property values work in
   "short_name": "Example",
   "start_url": "index.html",
   "theme_color": "red"
+}
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-manifest-is-valid
+```
+
+Note: You can make `npm` install it as a `devDependency` using the
+`--save-dev` parameter, or to install it globally, you can use the
+`-g` parameter. For other options see [`npm`'s
+documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "manifest-is-valid": "error"
+    },
+    ...
 }
 ```
 

--- a/packages/rule-meta-charset-utf-8/README.md
+++ b/packages/rule-meta-charset-utf-8/README.md
@@ -45,34 +45,6 @@ As for the charset meta tag, always use `<meta charset="utf-8">` as:
   avoiding potential encoding-related security issues ([such as the
   one in old IE][ie issue]).
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-meta-charset-utf-8
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "meta-charset-utf-8": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks if `<meta charset="utf-8">` is specified as the first
@@ -147,6 +119,34 @@ The `meta charset` is not the first thing in `<head>`:
     </head>
     <body>...</body>
 </html>
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-meta-charset-utf-8
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "meta-charset-utf-8": "error"
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/rule-meta-theme-color/README.md
+++ b/packages/rule-meta-theme-color/README.md
@@ -48,34 +48,6 @@ Note that:
     web app manifest file so it allows for better individual page level
     customization.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-meta-theme-color
-```
-
-Note: You can make `npm` install it as a `devDependency` using the
-`--save-dev` parameter, or to install it globally, you can use the
-`-g` parameter. For other options see [`npm`'s
-documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "meta-theme-color": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks if a single `theme-color` meta tag is specified in
@@ -199,6 +171,34 @@ color] supported everywhere:
     </head>
     <body>...</body>
 </html>
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-meta-theme-color
+```
+
+Note: You can make `npm` install it as a `devDependency` using the
+`--save-dev` parameter, or to install it globally, you can use the
+`-g` parameter. For other options see [`npm`'s
+documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "meta-theme-color": "error"
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/rule-meta-viewport/README.md
+++ b/packages/rule-meta-viewport/README.md
@@ -92,34 +92,6 @@ Notes:
   ignored by some mobile browsers such as [Safari for iOS 10+][ios
   10 interaction behaviors].
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-meta-viewport
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "meta-viewport": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks if the `viewport` meta tag was specified a single
@@ -250,6 +222,34 @@ That this rule takes into consideration the [targeted
 browsers](../index.md#browser-configuration), and if no
 versions of Safari for iOS < 9 are included, it will
 not require `initial-scale=1`.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-meta-viewport
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "meta-viewport": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-minified-js/README.md
+++ b/packages/rule-minified-js/README.md
@@ -9,34 +9,6 @@ This includes removing unused variables and methods, renaming variables
 and methods to smaller names, removing code comments, etc.
 Minification should generate a smaller file, and thus less code to parse.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-minified-js
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation][NPM documentation].
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": ["javascript"],
-    "rules": {
-        "minified-js": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule generates an *"Improvement Index"* value for the script content
@@ -78,6 +50,34 @@ that with a custom value in your [`.sonarwhalrc`][sonarwhalrc] config:
         "minified-js": ["error", {
             "threshold": 80
         }]
+    },
+    ...
+}
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-minified-js
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation][NPM documentation].
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": ["javascript"],
+    "rules": {
+        "minified-js": "error"
     },
     ...
 }

--- a/packages/rule-no-bom/README.md
+++ b/packages/rule-no-bom/README.md
@@ -14,6 +14,21 @@ precedence to BOM for the encoding.
 
 You can learn about other problems in [this section][bom problems].
 
+## What does the rule check?
+
+This rule checks that all text based media type files are served without the
+BOM character at the beginning.
+
+### Examples that **trigger** the rule
+
+A text file (such as HTML) that starts with the BOM character `U+FEFF`
+will fail.
+
+### Examples that **pass** the rule
+
+A text file (such as HTML) that doesn't start with the BOM character `U+FEFF`
+will pass.
+
 ## How to use this rule?
 
 To use it you will have to install it via `npm`:
@@ -41,21 +56,6 @@ configuration file:
     ...
 }
 ```
-
-## What does the rule check?
-
-This rule checks that all text based media type files are served without the
-BOM character at the beginning.
-
-### Examples that **trigger** the rule
-
-A text file (such as HTML) that starts with the BOM character `U+FEFF`
-will fail.
-
-### Examples that **pass** the rule
-
-A text file (such as HTML) that doesn't start with the BOM character `U+FEFF`
-will pass.
 
 ## Further Reading
 

--- a/packages/rule-no-disallowed-headers/README.md
+++ b/packages/rule-no-disallowed-headers/README.md
@@ -28,34 +28,6 @@ support and usage, it’s being deprecated (along with the related
 `Public-Key-Pins-Report-Only` header), and can easily create a lot
 of problems if not done correctly][hpkp deprecation].
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-no-disallowed-headers
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "no-disallowed-headers": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 By default, the rule checks if responses include one of the following
@@ -267,6 +239,34 @@ HTTP header, but not with `Custom-Header`.
             "include": ["Custom-Header"]
         }],
         ...
+    },
+    ...
+}
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-no-disallowed-headers
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "no-disallowed-headers": "error"
     },
     ...
 }

--- a/packages/rule-no-friendly-error-pages/README.md
+++ b/packages/rule-no-friendly-error-pages/README.md
@@ -23,34 +23,6 @@ as [Chrome][chromium issue].
 Although it's possible for users of `Internet Explorer` to disable the
 `Show friendly HTTP error messages` functionality, it is not typical.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-no-friendly-error-pages
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "no-friendly-error-pages": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule looks at all responses and checks if any of them have one
@@ -153,6 +125,34 @@ HTTP/... 500 Internal Server Error
         <p>......................................................................</p>
     </body>
 </html>
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-no-friendly-error-pages
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "no-friendly-error-pages": "error"
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/rule-no-html-only-headers/README.md
+++ b/packages/rule-no-html-only-headers/README.md
@@ -9,34 +9,6 @@ Some HTTP headers do not make sense to be sent for non-HTML
 resources, as sending them does not provide any value to users,
 and contributes to header bloat.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-no-html-only-headers
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "no-html-only-headers": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks if non-HTML responses include any of the following
@@ -251,6 +223,34 @@ file will make the rule allow non-HTML resources to be served with the
             "include": ["Custom-Header"]
         }],
         ...
+    },
+    ...
+}
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-no-html-only-headers
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "no-html-only-headers": "error"
     },
     ...
 }

--- a/packages/rule-no-http-redirects/README.md
+++ b/packages/rule-no-http-redirects/README.md
@@ -25,34 +25,6 @@ impact of redirects is felt even more by mobile users, where the [network
 latency is usually higher][pagespeed-insights].
 As a rule of thumb, the more you can avoid redirects the better.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-no-http-redirects
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "no-http-redirects": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule checks:
@@ -90,6 +62,34 @@ file will allow 3 redirects for resources and 1 for the main URL:
             "max-html-redirects": 1
         }],
         ...
+    },
+    ...
+}
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-no-http-redirects
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "no-http-redirects": "error"
     },
     ...
 }

--- a/packages/rule-no-protocol-relative-urls/README.md
+++ b/packages/rule-no-protocol-relative-urls/README.md
@@ -45,34 +45,6 @@ when using protocol relative URLs include:
   a high-value target, and therefore, are much more likely to be
   attacked than most of the individual sites that use them.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-no-protocol-relative-urls
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "no-protocol-relative-urls": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks for protocol-relative URLs.
@@ -101,6 +73,34 @@ does.
 
 ```html
 <script src="https://example2.com/script.js"></script>
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-no-protocol-relative-urls
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "no-protocol-relative-urls": "error"
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/rule-no-vulnerable-javascript-libraries/README.md
+++ b/packages/rule-no-vulnerable-javascript-libraries/README.md
@@ -13,34 +13,6 @@ Making sure your website dependencies are free of known vulnerabilities
 is important in preventing malicious attacks such as [cross-site scripting][XSS]
 attacks that can be used to compromise web site information.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-no-vulnerable-javascript-libraries
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "no-vulnerable-javascript-libraries": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rules uses Snyk’s [Vulnerability DB][snykdb] and
@@ -75,6 +47,34 @@ and `high`.
 
 If you configure this rule to `high`, and `sonarwhal` only finds
 `low` or `medium` vulnerabilities, no issues will be raised.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-no-vulnerable-javascript-libraries
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "no-vulnerable-javascript-libraries": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-performance-budget/README.md
+++ b/packages/rule-performance-budget/README.md
@@ -21,34 +21,6 @@ mindful not only about the size of their sites, but also the number of
 requests, different domains, third party scripts, etc. The time required by a
 browser to download a 200kB file is not the same than 20 files of 10kB.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-performance-budget
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "performance-budget": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule calculates how long it will take to download all the resources loaded
@@ -169,6 +141,34 @@ This means that if the user changes the `connectionType` but not the
 * Any combination of sizes, redirects, requests to different domains, etc. that
   make the site load in or under 5s on a `3GFast` network using the established
   formula.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-performance-budget
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "performance-budget": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-sri/README.md
+++ b/packages/rule-sri/README.md
@@ -21,34 +21,6 @@ Subresource integrity [is a standard][sri spec] that mitigates this by ensuring
 that an exact representation of a resource, and only that representation, loads
 and executes.
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-sri
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "sri": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule checks that a website uses correctly SRI, more especifically:
@@ -161,6 +133,34 @@ change it to `sha256`, or `sha512` by specifying that in the
 
 The above will validate that the `integrity` of all scripts and styles use
 `sha512`.
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-sri
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "sri": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-ssllabs/README.md
+++ b/packages/rule-ssllabs/README.md
@@ -15,34 +15,6 @@ developing their applications.
 ***From [SSL Labs’ SSL and TLS Deployment Best Practices][ssl best
 practices]***
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-ssllabs
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "ssllabs": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 This rule uses the [SSL Labs API][ssllabs api] via
@@ -116,6 +88,34 @@ The list of possible parameters is available in [SSL Labs’
 documentation][ssllabs protocol calls] with the difference
 that `on/off` parameters are `boolean`s in our case as shown
 in [`node-ssllabs`’ advanced usage][node-ssllabs usage].
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-ssllabs
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "ssllabs": "error"
+    },
+    ...
+}
+```
 
 ## Further Reading
 

--- a/packages/rule-strict-transport-security/README.md
+++ b/packages/rule-strict-transport-security/README.md
@@ -36,34 +36,6 @@ More information about HTTP Strict Transport (HSTS), please see:
 * [HTTP Strict Transport Security wiki][hsts wiki]
 * [HTTP Strict Transport Security Cheat Sheet][hsts cheat sheat]
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-strict-transport-security
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "strict-transport-security": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 For a site served over HTTPS, this rule checks the following:
@@ -243,6 +215,34 @@ E.g. The following configuration will enable the `preload` validation.
             "checkPreload": true
         }],
         ...
+    },
+    ...
+}
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-strict-transport-security
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "strict-transport-security": "error"
     },
     ...
 }

--- a/packages/rule-typescript-config/README.md
+++ b/packages/rule-typescript-config/README.md
@@ -3,6 +3,21 @@
 `typescript-config` contains rules to check if your TypeScript configuration
 has the most recommended configuration.
 
+## Why is this important?
+
+If you are building an app or a website using TypeScript, you
+need to be sure that your configuration is the best for your needs.
+
+## Rules
+
+* [typescript-config/import-helpers][import-helpers]
+* [typescript-config/is-valid][is-valid]
+* [typescript-config/no-comment][no-comment]
+* [typescript-config/strict][strict]
+* [typescript-config/target][target]
+
+## How to use these rules?
+
 To use it you will have to install it via `npm`:
 
 ```bash
@@ -30,19 +45,6 @@ configuration file:
     ...
 }
 ```
-
-## Why is this important?
-
-If you are building an app or a website using TypeScript, you
-need to be sure that your configuration is the best for your needs.
-
-## Rules
-
-* [typescript-config/import-helpers][import-helpers]
-* [typescript-config/is-valid][is-valid]
-* [typescript-config/no-comment][no-comment]
-* [typescript-config/strict][strict]
-* [typescript-config/target][target]
 
 ## Further Reading
 

--- a/packages/rule-validate-set-cookie-header/README.md
+++ b/packages/rule-validate-set-cookie-header/README.md
@@ -39,34 +39,6 @@ are properly used, and also offers to validate the `Set-Cookie` header syntax.
 Note: More information about `Set-cookie` header is available in
 the [MDN web docs][set-cookie web doc].
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-validate-set-cookie-header
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "validate-set-cookie-header": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 * `Secure` and `HttpOnly` cookies:
@@ -191,6 +163,34 @@ HTTP/... 200 OK
 
 ...
 Set-Cookie: __Secure-ID=123; Secure; Domain=example.com; HttpOnly
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-validate-set-cookie-header
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "validate-set-cookie-header": "error"
+    },
+    ...
+}
 ```
 
 <!-- Link labels: -->

--- a/packages/rule-webpack-config/README.md
+++ b/packages/rule-webpack-config/README.md
@@ -3,6 +3,22 @@
 `webpack-config` contains set of rules to check if your webpack configuration
 file (`webpack.config.js`) has the most recommended configuration.
 
+## Why is this important?
+
+If you are building an app or a website using webpack, you
+need to be sure that your configuration is the best for your needs.
+
+## Rules
+
+* [webpack-config/config-exists][config-exists]
+* [webpack-config/is-installed][is-installed]
+* [webpack-config/is-valid][is-valid]
+* [webpack-config/module-esnext-typescript][module-esnext-typescript]
+* [webpack-config/modules-false-babel][modules-false-babel]
+* [webpack-config/no-devtool-in-prod][no-devtool-in-prod]
+
+## How to use these rules?
+
 To use it you will have to install it via `npm`:
 
 ```bash
@@ -33,20 +49,6 @@ configuration file:
     ...
 }
 ```
-
-## Why is this important?
-
-If you are building an app or a website using webpack, you
-need to be sure that your configuration is the best for your needs.
-
-## Rules
-
-* [webpack-config/config-exists][config-exists]
-* [webpack-config/is-installed][is-installed]
-* [webpack-config/is-valid][is-valid]
-* [webpack-config/module-esnext-typescript][module-esnext-typescript]
-* [webpack-config/modules-false-babel][modules-false-babel]
-* [webpack-config/no-devtool-in-prod][no-devtool-in-prod]
 
 ## Further Reading
 

--- a/packages/rule-x-content-type-options/README.md
+++ b/packages/rule-x-content-type-options/README.md
@@ -34,34 +34,6 @@ stylesheets][fetch spec blocking], and sending the header for other
 resources (such as images) when they are served with the wrong media
 type may [create problems in older browsers][fetch spec issue].
 
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-x-content-type-options
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "x-content-type-options": "error"
-    },
-    ...
-}
-```
-
 ## What does the rule check?
 
 The rule checks if all scripts and stylesheets are served with the
@@ -103,6 +75,34 @@ HTTP/... 200 OK
 ...
 Content-Type: text/javascript; charset=utf-8
 X-Content-Type-Options: nosniff
+```
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-x-content-type-options
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "x-content-type-options": "error"
+    },
+    ...
+}
 ```
 
 ## Further Reading

--- a/packages/sonarwhal/src/lib/cli/wizards/templates/new-rule/readme.md.hbs
+++ b/packages/sonarwhal/src/lib/cli/wizards/templates/new-rule/readme.md.hbs
@@ -6,6 +6,33 @@
 
 Explain why this {{#if isMulti}}package{{else}}rule{{/if}} is important for your users
 
+{{#if isMulti}}
+## Rules
+
+{{#each rules}}
+* [{{../normalizedName}}/{{normalizedName}}][{{normalizedName}}]
+{{/each}}
+{{else}}
+## What does the rule check?
+
+A bit more detail of what the rule does.
+
+### Examples that **trigger** the rule
+
+A list of code examples that will fail this rule.
+It's good to put some edge cases in here.
+
+### Examples that **pass** the rule
+
+A list of code examples that will pass this rule.
+It's good to put some edge cases in here.
+
+## Can the rule be configured?
+
+If this rule allows some configuration, please put the format and
+options for the user.
+{{/if}}
+
 ## How to use {{#if isMulti}}these rules{{else}}this rule{{/if}}?
 
 To use it you will have to install it via `npm`:
@@ -35,33 +62,6 @@ configuration file:
     ...
 }
 ```
-
-{{#if isMulti}}
-## Rules
-
-{{#each rules}}
-* [{{../normalizedName}}/{{normalizedName}}][{{normalizedName}}]
-{{/each}}
-{{else}}
-## What does the rule check?
-
-A bit more detail of what the rule does.
-
-### Examples that **trigger** the rule
-
-A list of code examples that will fail this rule.
-It's good to put some edge cases in here.
-
-### Examples that **pass** the rule
-
-A list of code examples that will pass this rule.
-It's good to put some edge cases in here.
-
-## Can the rule be configured?
-
-If this rule allows some configuration, please put the format and
-options for the user.
-{{/if}}
 
 ## Further Reading
 


### PR DESCRIPTION
Fix #1018

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
