### PR TITLE
Fix: Lazy load modules depending on the task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 *.pid
 *.STALE
+*.trace
 .DS_Store
 .eslintcache
 .nyc_output

--- a/packages/sonarwhal/src/lib/cli/actions.ts
+++ b/packages/sonarwhal/src/lib/cli/actions.ts
@@ -5,12 +5,11 @@ import { CLIOptions } from '../types';
 
 /** Wrapper to dynamically load the different CLI tasks depending on a condition */
 const action = (pkg: string, condition?: string): (actions: CLIOptions) => Promise<boolean> => {
-    return async (actions: CLIOptions): Promise<boolean> => {
-        if (!condition || actions[condition]) {
+    return async (options: CLIOptions): Promise<boolean> => {
+        if (!condition || options[condition]) {
             const { default: task } = await import(pkg);
 
-            // TODO: we shouldn't have to pass actions
-            return await task(actions);
+            return await task(options);
         }
 
         return false;

--- a/packages/sonarwhal/src/lib/cli/actions.ts
+++ b/packages/sonarwhal/src/lib/cli/actions.ts
@@ -1,13 +1,29 @@
 /**
  * @fileoverview Exports all the actions the CLI is capable of doing.
  */
-import { CLIOptions } from '../types'; // eslint-disable-line no-unused-vars
-import { newRule } from './wizards/new-rule';
-import { initSonarwhalrc } from './wizards/init';
-import { printHelp } from './help';
-import { printVersion } from './version';
-import { analyze } from './analyze';
-import { newParser } from './wizards/new-parser';
+import { CLIOptions } from '../types';
+
+/** Wrapper to dynamically load the different CLI tasks depending on a condition */
+const action = (pkg: string, condition?: string): (actions: CLIOptions) => Promise<boolean> => {
+    return async (actions: CLIOptions): Promise<boolean> => {
+        if (!condition || actions[condition]) {
+            const { default: task } = await import(pkg);
+
+            // TODO: we shouldn't have to pass actions
+            return await task(actions);
+        }
+
+        return false;
+    };
+};
 
 /** All the action handlers for the CLI. */
-export const cliActions: Array<(action: CLIOptions) => Promise<boolean> > = [newRule, newParser, initSonarwhalrc, printVersion, analyze, printHelp];
+export const cliActions: Array<(action: CLIOptions) => Promise<boolean>> =
+    [
+        action('./wizards/new-rule', 'newRule'),
+        action('./wizards/new-parser', 'newParser'),
+        action('./wizards/init', 'init'),
+        action('./version', 'version'),
+        action('./analyze', '_'),
+        action('./help')
+    ];

--- a/packages/sonarwhal/src/lib/cli/analyze.ts
+++ b/packages/sonarwhal/src/lib/cli/analyze.ts
@@ -16,7 +16,7 @@ import * as logger from '../utils/logging';
 import { cutString } from '../utils/misc';
 import * as resourceLoader from '../utils/resource-loader';
 import { installPackages } from '../utils/npm';
-import { initSonarwhalrc } from './wizards/init';
+import initSonarwhalrc from './wizards/init';
 
 const each = promisify(async.each);
 const debug: debug.IDebugger = d(__filename);
@@ -143,7 +143,7 @@ const setUpUserFeedback = (sonarwhalInstance: Sonarwhal, spinner: ORA) => {
 export let sonarwhal: Sonarwhal = null;
 
 /** Analyzes a website if indicated by `actions`. */
-export const analyze = async (actions: CLIOptions): Promise<boolean> => {
+export default async (actions: CLIOptions): Promise<boolean> => {
     if (!actions._) {
         return false;
     }

--- a/packages/sonarwhal/src/lib/cli/analyze.ts
+++ b/packages/sonarwhal/src/lib/cli/analyze.ts
@@ -47,7 +47,7 @@ const askUserToCreateConfig = async (): Promise<boolean> => {
 
     const { default: initSonarwhalrc } = await import('./wizards/init');
 
-    await initSonarwhalrc({ init: true } as CLIOptions);
+    await initSonarwhalrc();
     logger.log(`Configuration file .sonarwhalrc was created.`);
 
     return true;
@@ -145,9 +145,6 @@ export let sonarwhal: Sonarwhal = null;
 
 /** Analyzes a website if indicated by `actions`. */
 export default async (actions: CLIOptions): Promise<boolean> => {
-    if (!actions._) {
-        return false;
-    }
 
     const targets: Array<URL> = getAsUris(actions._);
 

--- a/packages/sonarwhal/src/lib/cli/analyze.ts
+++ b/packages/sonarwhal/src/lib/cli/analyze.ts
@@ -16,7 +16,6 @@ import * as logger from '../utils/logging';
 import { cutString } from '../utils/misc';
 import * as resourceLoader from '../utils/resource-loader';
 import { installPackages } from '../utils/npm';
-import initSonarwhalrc from './wizards/init';
 
 const each = promisify(async.each);
 const debug: debug.IDebugger = d(__filename);
@@ -45,6 +44,8 @@ const askUserToCreateConfig = async (): Promise<boolean> => {
     if (!launchInit.confirm) {
         return false;
     }
+
+    const { default: initSonarwhalrc } = await import('./wizards/init');
 
     await initSonarwhalrc({ init: true } as CLIOptions);
     logger.log(`Configuration file .sonarwhalrc was created.`);

--- a/packages/sonarwhal/src/lib/cli/help.ts
+++ b/packages/sonarwhal/src/lib/cli/help.ts
@@ -3,7 +3,7 @@ import * as logger from '../utils/logging';
 import { CLIOptions } from '../types';
 
 /** Prints the help menu in the console. */
-export const printHelp = (actions: CLIOptions): Promise<boolean> => {
+export default (actions: CLIOptions): Promise<boolean> => {
     // We print the help
     const entries = Object.entries(actions);
     const showHelp = entries.reduce((result, [key, value]) => {

--- a/packages/sonarwhal/src/lib/cli/version.ts
+++ b/packages/sonarwhal/src/lib/cli/version.ts
@@ -1,12 +1,8 @@
-import { CLIOptions } from '../types';
 import * as logger from '../utils/logging';
 import { getSonarwhalPackage } from '../utils/misc';
 
 /** Prints the current sonarwhal version in the console. */
-export default (actions: CLIOptions): Promise<boolean> => {
-    if (!actions.version) {
-        return Promise.resolve(false);
-    }
+export default (): Promise<boolean> => {
 
     const pkg = getSonarwhalPackage();
 

--- a/packages/sonarwhal/src/lib/cli/version.ts
+++ b/packages/sonarwhal/src/lib/cli/version.ts
@@ -3,7 +3,7 @@ import * as logger from '../utils/logging';
 import { getSonarwhalPackage } from '../utils/misc';
 
 /** Prints the current sonarwhal version in the console. */
-export const printVersion = (actions: CLIOptions): Promise<boolean> => {
+export default (actions: CLIOptions): Promise<boolean> => {
     if (!actions.version) {
         return Promise.resolve(false);
     }

--- a/packages/sonarwhal/src/lib/cli/wizards/init.ts
+++ b/packages/sonarwhal/src/lib/cli/wizards/init.ts
@@ -163,8 +163,8 @@ const customConfig = async (): Promise<InitUserConfig> => {
  * * an existing published configuration package
  * * the installed resources
  */
-export const initSonarwhalrc = async (options: CLIOptions): Promise<boolean> => {
-    if (!options.init) {
+export default async (actions: CLIOptions): Promise<boolean> => {
+    if (!actions.init) {
         return false;
     }
 

--- a/packages/sonarwhal/src/lib/cli/wizards/init.ts
+++ b/packages/sonarwhal/src/lib/cli/wizards/init.ts
@@ -14,7 +14,7 @@ import { promisify } from 'util';
 
 import * as inquirer from 'inquirer';
 
-import { CLIOptions, UserConfig } from '../../types';
+import { UserConfig } from '../../types';
 import { debug as d } from '../../utils/debug';
 import * as logger from '../../utils/logging';
 import { getInstalledResources, getCoreResources } from '../../utils/resource-loader';
@@ -163,10 +163,7 @@ const customConfig = async (): Promise<InitUserConfig> => {
  * * an existing published configuration package
  * * the installed resources
  */
-export default async (actions: CLIOptions): Promise<boolean> => {
-    if (!actions.init) {
-        return false;
-    }
+export default async (): Promise<boolean> => {
 
     debug('Starting --init');
 

--- a/packages/sonarwhal/src/lib/cli/wizards/new-parser.ts
+++ b/packages/sonarwhal/src/lib/cli/wizards/new-parser.ts
@@ -5,7 +5,6 @@ import * as fs from 'fs-extra';
 import * as inquirer from 'inquirer';
 import * as mkdirp from 'mkdirp';
 
-import { CLIOptions } from '../../types';
 import * as logger from '../../utils/logging';
 import { isOfficial, normalizeStringByDelimiter as normalize, writeFileAsync } from '../../utils/misc';
 import { escapeSafeString, compileTemplate, sonarwhalPackage } from '../../utils/handlebars';
@@ -265,10 +264,7 @@ const generateFiles = async (data: NewParser) => {
  * ------------------------------------------------------------------------------
  */
 /** Generate a new parser. */
-export default async (actions: CLIOptions): Promise<boolean> => {
-    if (!actions.newParser) {
-        return false;
-    }
+export default async (): Promise<boolean> => {
 
     const results: QuestionsType = (await inquirer.prompt(questions()) as QuestionsType);
     const eventsSelected: Array<EventType> = [];

--- a/packages/sonarwhal/src/lib/cli/wizards/new-parser.ts
+++ b/packages/sonarwhal/src/lib/cli/wizards/new-parser.ts
@@ -265,7 +265,7 @@ const generateFiles = async (data: NewParser) => {
  * ------------------------------------------------------------------------------
  */
 /** Generate a new parser. */
-export const newParser = async (actions: CLIOptions): Promise<boolean> => {
+export default async (actions: CLIOptions): Promise<boolean> => {
     if (!actions.newParser) {
         return false;
     }

--- a/packages/sonarwhal/src/lib/cli/wizards/new-rule.ts
+++ b/packages/sonarwhal/src/lib/cli/wizards/new-rule.ts
@@ -6,7 +6,6 @@ import * as fs from 'fs-extra';
 import * as inquirer from 'inquirer';
 import * as mkdirp from 'mkdirp';
 
-import { CLIOptions } from '../../types';
 import { Category } from '../../enums/category';
 import { RuleScope } from '../../enums/rulescope';
 import * as logger from '../../utils/logging';
@@ -375,11 +374,7 @@ const generateRuleFiles = async (destination: string, data) => {
 };
 
 /** Add a new rule. */
-export default async (actions: CLIOptions): Promise<boolean> => {
-    if (!actions.newRule) {
-        return false;
-    }
-
+export default async (): Promise<boolean> => {
     try {
         const results = await inquirer.prompt(questions(QuestionsType.main));
         const rules = [];

--- a/packages/sonarwhal/src/lib/cli/wizards/new-rule.ts
+++ b/packages/sonarwhal/src/lib/cli/wizards/new-rule.ts
@@ -375,7 +375,7 @@ const generateRuleFiles = async (destination: string, data) => {
 };
 
 /** Add a new rule. */
-export const newRule = async (actions: CLIOptions): Promise<boolean> => {
+export default async (actions: CLIOptions): Promise<boolean> => {
     if (!actions.newRule) {
         return false;
     }

--- a/packages/sonarwhal/tests/lib/cli/analyze.ts
+++ b/packages/sonarwhal/tests/lib/cli/analyze.ts
@@ -62,7 +62,7 @@ proxyquire('../../../src/lib/cli/analyze', {
     ora
 });
 
-import * as analyzer from '../../../src/lib/cli/analyze';
+import { default as analyze, sonarwhal } from '../../../src/lib/cli/analyze';
 
 test.beforeEach((t) => {
     sinon.spy(logger, 'log');
@@ -102,7 +102,7 @@ test.serial('If config is not defined, it should get the config file from the di
         .onFirstCall()
         .returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.true(t.context.SonarwhalConfig.getFilenameForDirectory.called);
 
@@ -127,7 +127,7 @@ test.serial('If config path doesn\'t exist, it should create a configuration fil
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
     sandbox.stub(inquirer, 'prompt').resolves({ confirm: true });
 
-    await t.notThrows(analyzer.analyze(actions));
+    await t.notThrows(analyze(actions));
 
     t.true(t.context.inquirer.prompt.calledOnce);
     t.is(t.context.inquirer.prompt.args[0][0][0].name, 'confirm');
@@ -157,7 +157,7 @@ test.serial('If config file does not exist, it should create a configuration fil
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
     sandbox.stub(inquirer, 'prompt').resolves({ confirm: true });
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.true(t.context.inquirer.prompt.calledOnce);
     t.is(t.context.inquirer.prompt.args[0][0][0].name, 'confirm');
@@ -181,7 +181,7 @@ test.serial('If config file does not exist and user refuses to create a configur
         .throws(error);
     sandbox.stub(inquirer, 'prompt').resolves({ confirm: false });
 
-    const result = await analyzer.analyze(actions);
+    const result = await analyze(actions);
 
     t.true(t.context.inquirer.prompt.calledOnce);
     t.is(t.context.inquirer.prompt.args[0][0][0].name, 'confirm');
@@ -205,7 +205,7 @@ test.serial('If configuration file exists, it should use it', async (t) => {
 
     const customConfigOptions = ({ _: ['http://localhost'], config: 'configfile.cfg' } as CLIOptions);
 
-    await analyzer.analyze(customConfigOptions);
+    await analyze(customConfigOptions);
 
     t.false(t.context.SonarwhalConfig.getFilenameForDirectory.called);
     t.true(t.context.SonarwhalConfig.loadConfigFile.args[0][0].endsWith('configfile.cfg'));
@@ -246,7 +246,7 @@ test.serial('If executeOn returns an error, it should exit with code 1 and call 
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'loadConfigFile').returns({});
 
-    const exitCode = await analyzer.analyze(actions);
+    const exitCode = await analyze(actions);
 
     t.true(FakeFormatter.called);
     t.false(exitCode);
@@ -267,7 +267,7 @@ test.serial('If executeOn returns an error, it should call to spinner.fail()', a
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').resolves([{ severity: Severity.error }]);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.true(t.context.spinner.fail.calledOnce);
 
@@ -287,7 +287,7 @@ test.serial('If executeOn throws an exception, it should exit with code 1', asyn
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').throws(new Error());
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    const result = await analyzer.analyze(actions);
+    const result = await analyze(actions);
 
     t.false(result);
 
@@ -307,7 +307,7 @@ test.serial('If executeOn throws an exception, it should call to spinner.fail()'
     sandbox.stub(sonarwhalContainer.Sonarwhal.prototype, 'executeOn').throws(new Error());
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.true(t.context.spinner.fail.calledOnce);
 
@@ -346,7 +346,7 @@ test.serial('If executeOn returns no errors, it should exit with code 0 and call
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    const exitCode = await analyzer.analyze(actions);
+    const exitCode = await analyze(actions);
 
     t.true(FakeFormatter.called);
     t.true(exitCode);
@@ -386,7 +386,7 @@ test.serial('If executeOn returns no errors, it should call to spinner.succeed()
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.true(t.context.spinner.succeed.calledOnce);
 
@@ -418,7 +418,7 @@ test.serial('Event fetch::start should write a message in the spinner', async (t
         return [new FakeFormatter()];
     });
     sandbox.stub(sonarwhalObj, 'executeOn').callsFake(async () => {
-        await analyzer.sonarwhal.emitAsync('fetch::start', { resource: 'http://localhost/' });
+        await sonarwhal.emitAsync('fetch::start', { resource: 'http://localhost/' });
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'getFilenameForDirectory').returns('/config/path');
@@ -426,7 +426,7 @@ test.serial('Event fetch::start should write a message in the spinner', async (t
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.is(spinner.text, 'Downloading http://localhost/');
 
@@ -458,7 +458,7 @@ test.serial('Event fetch::end should write a message in the spinner', async (t) 
         return [new FakeFormatter()];
     });
     sandbox.stub(sonarwhalObj, 'executeOn').callsFake(async () => {
-        await analyzer.sonarwhal.emitAsync('fetch::end', { resource: 'http://localhost/' });
+        await sonarwhal.emitAsync('fetch::end', { resource: 'http://localhost/' });
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'getFilenameForDirectory').returns('/config/path');
@@ -466,7 +466,7 @@ test.serial('Event fetch::end should write a message in the spinner', async (t) 
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.is(spinner.text, 'http://localhost/ downloaded');
 
@@ -498,7 +498,7 @@ test.serial('Event fetch::end::html should write a message in the spinner', asyn
         return [new FakeFormatter()];
     });
     sandbox.stub(sonarwhalObj, 'executeOn').callsFake(async () => {
-        await analyzer.sonarwhal.emitAsync('fetch::end::html', { resource: 'http://localhost/' });
+        await sonarwhal.emitAsync('fetch::end::html', { resource: 'http://localhost/' });
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'getFilenameForDirectory').returns('/config/path');
@@ -506,7 +506,7 @@ test.serial('Event fetch::end::html should write a message in the spinner', asyn
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.is(spinner.text, 'http://localhost/ downloaded');
 
@@ -538,7 +538,7 @@ test.serial('Event traverse::up should write a message in the spinner', async (t
         return [new FakeFormatter()];
     });
     sandbox.stub(sonarwhalObj, 'executeOn').callsFake(async () => {
-        await analyzer.sonarwhal.emitAsync('traverse::up', { resource: 'http://localhost/' });
+        await sonarwhal.emitAsync('traverse::up', { resource: 'http://localhost/' });
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(config.SonarwhalConfig, 'getFilenameForDirectory').returns('/config/path');
@@ -546,7 +546,7 @@ test.serial('Event traverse::up should write a message in the spinner', async (t
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.is(spinner.text, 'Traversing the DOM');
 
@@ -578,7 +578,7 @@ test.serial('Event traverse::end should write a message in the spinner', async (
         return [new FakeFormatter()];
     });
     sandbox.stub(sonarwhalObj, 'executeOn').callsFake(async () => {
-        await analyzer.sonarwhal.emitAsync('traverse::end', { resource: 'http://localhost/' });
+        await sonarwhal.emitAsync('traverse::end', { resource: 'http://localhost/' });
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(t.context.SonarwhalConfig, 'getFilenameForDirectory').returns('/config/path');
@@ -586,7 +586,7 @@ test.serial('Event traverse::end should write a message in the spinner', async (
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.is(spinner.text, 'Traversing finished');
 
@@ -618,7 +618,7 @@ test.serial('Event scan::end should write a message in the spinner', async (t) =
         return [new FakeFormatter()];
     });
     sandbox.stub(sonarwhalObj, 'executeOn').callsFake(async () => {
-        await analyzer.sonarwhal.emitAsync('scan::end', { resource: 'http://localhost/' });
+        await sonarwhal.emitAsync('scan::end', { resource: 'http://localhost/' });
     });
     sandbox.stub(sonarwhalContainer, 'Sonarwhal').returns(sonarwhalObj);
     sandbox.stub(config.SonarwhalConfig, 'getFilenameForDirectory').returns('/config/path');
@@ -626,7 +626,7 @@ test.serial('Event scan::end should write a message in the spinner', async (t) =
     sandbox.stub(t.context.SonarwhalConfig, 'fromConfig').returns({});
     sandbox.stub(t.context.SonarwhalConfig, 'validateRulesConfig').returns(validateRulesConfigResult);
 
-    await analyzer.analyze(actions);
+    await analyze(actions);
 
     t.is(spinner.text, 'Finishing...');
 
@@ -634,13 +634,13 @@ test.serial('Event scan::end should write a message in the spinner', async (t) =
 });
 
 test.serial('If no sites are defined, it should return false', async (t) => {
-    const result = await analyzer.analyze({ _: [] } as CLIOptions);
+    const result = await analyze({ _: [] } as CLIOptions);
 
     t.false(result);
 });
 
 test.serial('If _ property is not defined in actions, it should return false', async (t) => {
-    const result = await analyzer.analyze({} as CLIOptions);
+    const result = await analyze({} as CLIOptions);
 
     t.false(result);
 });

--- a/packages/sonarwhal/tests/lib/cli/help.ts
+++ b/packages/sonarwhal/tests/lib/cli/help.ts
@@ -11,7 +11,7 @@ const logger = {
 
 proxyquire('../../../src/lib/cli/help', { '../utils/logging': logger });
 
-import { printHelp } from '../../../src/lib/cli/help';
+import printHelp from '../../../src/lib/cli/help';
 
 test.beforeEach((t) => {
     sinon.spy(logger, 'log');

--- a/packages/sonarwhal/tests/lib/cli/version.ts
+++ b/packages/sonarwhal/tests/lib/cli/version.ts
@@ -2,8 +2,6 @@ import test from 'ava';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 
-import { CLIOptions } from '../../../src/lib/types';
-
 const logger = {
     error() { },
     log() { }

--- a/packages/sonarwhal/tests/lib/cli/version.ts
+++ b/packages/sonarwhal/tests/lib/cli/version.ts
@@ -12,7 +12,7 @@ const logger = {
 
 proxyquire('../../../src/lib/cli/version', { '../utils/logging': logger });
 
-import { printVersion } from '../../../src/lib/cli/version';
+import printVersion from '../../../src/lib/cli/version';
 
 test.beforeEach((t) => {
     sinon.spy(logger, 'log');

--- a/packages/sonarwhal/tests/lib/cli/version.ts
+++ b/packages/sonarwhal/tests/lib/cli/version.ts
@@ -4,7 +4,6 @@ import * as sinon from 'sinon';
 
 import { CLIOptions } from '../../../src/lib/types';
 
-const actions = ({ version: true } as CLIOptions);
 const logger = {
     error() { },
     log() { }
@@ -27,15 +26,9 @@ test.afterEach.always((t) => {
 });
 
 test.serial('If version option is defined, it should print the current version and return true', async (t) => {
-    const result = await printVersion(actions);
+    const result = await printVersion();
 
     t.true(result);
     t.true(t.context.logger.log.calledOnce);
     t.true(t.context.logger.log.args[0][0].startsWith('v'));
-});
-
-test.serial('If version is not an option, it should return false', async (t) => {
-    const result = await printVersion(({}) as CLIOptions);
-
-    t.false(result);
 });

--- a/packages/sonarwhal/tests/lib/cli/wizards/init.ts
+++ b/packages/sonarwhal/tests/lib/cli/wizards/init.ts
@@ -3,9 +3,8 @@ import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import test from 'ava';
 
-import { CLIOptions, NpmPackage } from '../../../../src/lib/types';
+import { NpmPackage } from '../../../../src/lib/types';
 
-const actions = ({ init: true } as CLIOptions);
 const inquirer = { prompt() { } };
 const stubBrowserslistObject = { generateBrowserslistConfig() { } };
 const resourceLoader = {
@@ -105,7 +104,7 @@ test.serial(`initSonarwhalrc should install the configuration package if user ch
         .onSecondCall()
         .resolves(configAnswer);
 
-    await initSonarwhalrc(actions);
+    await initSonarwhalrc();
 
     const fileData = JSON.parse(t.context.promisify.args[0][1]);
 
@@ -139,7 +138,7 @@ test.serial(`initSonarwhalrc shouldn't install the configuration package if user
         .onSecondCall()
         .resolves(configAnswer);
 
-    await initSonarwhalrc(actions);
+    await initSonarwhalrc();
 
     const fileData = JSON.parse(t.context.promisify.args[0][1]);
 
@@ -178,7 +177,7 @@ test.serial(`"inquirer.prompt" should use the installed resources if the user do
         .onSecondCall()
         .resolves(answers);
 
-    await initSonarwhalrc(actions);
+    await initSonarwhalrc();
 
     const questions = (inquirer.prompt as sinon.SinonStub).args[1][0];
 
@@ -221,15 +220,9 @@ test.serial(`if instalation of a config package fails, "initSonarwhalrc" returns
         .onSecondCall()
         .resolves(configAnswer);
 
-    const result = await initSonarwhalrc(actions);
+    const result = await initSonarwhalrc();
 
     t.true(result, `initSonarwhalrc doesn't return true if installation of resources fails`);
 
     sandbox.restore();
-});
-
-test.serial('If init is not an option, it should return false', async (t) => {
-    const result = await initSonarwhalrc(({}) as CLIOptions);
-
-    t.false(result);
 });

--- a/packages/sonarwhal/tests/lib/cli/wizards/init.ts
+++ b/packages/sonarwhal/tests/lib/cli/wizards/init.ts
@@ -46,7 +46,7 @@ proxyquire('../../../../src/lib/cli/wizards/init', {
     util: stubUtilObject
 });
 
-import { initSonarwhalrc } from '../../../../src/lib/cli/wizards/init';
+import initSonarwhalrc from '../../../../src/lib/cli/wizards/init';
 
 test.beforeEach((t) => {
     sinon.stub(promisifyObject, 'promisify').resolves();

--- a/packages/sonarwhal/tests/lib/cli/wizards/new-parser.ts
+++ b/packages/sonarwhal/tests/lib/cli/wizards/new-parser.ts
@@ -4,10 +4,6 @@ import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import test from 'ava';
 
-import { CLIOptions } from '../../../../src/lib/types';
-
-const actions = ({ newParser: true } as CLIOptions);
-
 const fsExtra = { copy() { } };
 const inquirer = { prompt() { } };
 const misc = {
@@ -56,7 +52,7 @@ test.afterEach.always((t) => {
 
 
 test.serial('If newParser is not an option, it should return false', async (t) => {
-    const result = await newParser({} as CLIOptions);
+    const result = await newParser();
 
     t.false(result);
 });
@@ -82,7 +78,7 @@ test.serial('It should create a new official parser.', async (t) => {
         .onSecondCall()
         .resolves(parserEventsResult);
 
-    const result = await newParser(actions);
+    const result = await newParser();
 
     // 6 files (2 code + test + doc + tsconfig.json + package.json)
     t.is(t.context.handlebars.compileTemplate.callCount, 6, `Handlebars doesn't complile the right number of files`);
@@ -131,7 +127,7 @@ test.serial('It should create a new official parser with no duplicate events.', 
 
     t.context.inquirer = inquirer;
 
-    const result = await newParser(actions);
+    const result = await newParser();
     const questions = t.context.inquirer.prompt.args[3][0];
     const eventQuestion = questions.find((question) => {
         return question.name === 'event';
@@ -179,7 +175,7 @@ test.serial('It should create a new non-official parser.', async (t) => {
         .onSecondCall()
         .resolves(parserEventsResult);
 
-    const result = await newParser(actions);
+    const result = await newParser();
 
     // 7 files (2 code + test + doc + tsconfig.json + package.json + .sonarwhalrc)
     t.is(t.context.handlebars.compileTemplate.callCount, 7, `Handlebars doesn't complile the right number of files`);

--- a/packages/sonarwhal/tests/lib/cli/wizards/new-parser.ts
+++ b/packages/sonarwhal/tests/lib/cli/wizards/new-parser.ts
@@ -50,13 +50,6 @@ test.afterEach.always((t) => {
     t.context.handlebars.compileTemplate.restore();
 });
 
-
-test.serial('If newParser is not an option, it should return false', async (t) => {
-    const result = await newParser();
-
-    t.false(result);
-});
-
 test.serial('It should create a new official parser.', async (t) => {
     const parserInfoResult = {
         description: 'description',

--- a/packages/sonarwhal/tests/lib/cli/wizards/new-parser.ts
+++ b/packages/sonarwhal/tests/lib/cli/wizards/new-parser.ts
@@ -32,7 +32,7 @@ proxyquire('../../../../src/lib/cli/wizards/new-parser', {
     mkdirp
 });
 
-import * as parser from '../../../../src/lib/cli/wizards/new-parser';
+import newParser from '../../../../src/lib/cli/wizards/new-parser';
 
 test.beforeEach((t) => {
     sinon.stub(fsExtra, 'copy').resolves();
@@ -56,7 +56,7 @@ test.afterEach.always((t) => {
 
 
 test.serial('If newParser is not an option, it should return false', async (t) => {
-    const result = await parser.newParser({} as CLIOptions);
+    const result = await newParser({} as CLIOptions);
 
     t.false(result);
 });
@@ -82,7 +82,7 @@ test.serial('It should create a new official parser.', async (t) => {
         .onSecondCall()
         .resolves(parserEventsResult);
 
-    const result = await parser.newParser(actions);
+    const result = await newParser(actions);
 
     // 6 files (2 code + test + doc + tsconfig.json + package.json)
     t.is(t.context.handlebars.compileTemplate.callCount, 6, `Handlebars doesn't complile the right number of files`);
@@ -131,7 +131,7 @@ test.serial('It should create a new official parser with no duplicate events.', 
 
     t.context.inquirer = inquirer;
 
-    const result = await parser.newParser(actions);
+    const result = await newParser(actions);
     const questions = t.context.inquirer.prompt.args[3][0];
     const eventQuestion = questions.find((question) => {
         return question.name === 'event';
@@ -179,7 +179,7 @@ test.serial('It should create a new non-official parser.', async (t) => {
         .onSecondCall()
         .resolves(parserEventsResult);
 
-    const result = await parser.newParser(actions);
+    const result = await newParser(actions);
 
     // 7 files (2 code + test + doc + tsconfig.json + package.json + .sonarwhalrc)
     t.is(t.context.handlebars.compileTemplate.callCount, 7, `Handlebars doesn't complile the right number of files`);

--- a/packages/sonarwhal/tests/lib/cli/wizards/new-rule.ts
+++ b/packages/sonarwhal/tests/lib/cli/wizards/new-rule.ts
@@ -25,12 +25,6 @@ proxyquire('../../../../src/lib/cli/wizards/new-rule', {
 
 import newRule from '../../../../src/lib/cli/wizards/new-rule';
 
-test.serial('If newRule is not an option, it should return false', async (t) => {
-    const result = await newRule();
-
-    t.false(result);
-});
-
 test.serial('It creates a rule if the option multiple rules is false', async (t) => {
     const results = {
         category: 'pwa',

--- a/packages/sonarwhal/tests/lib/cli/wizards/new-rule.ts
+++ b/packages/sonarwhal/tests/lib/cli/wizards/new-rule.ts
@@ -26,10 +26,10 @@ proxyquire('../../../../src/lib/cli/wizards/new-rule', {
     mkdirp
 });
 
-import * as rule from '../../../../src/lib/cli/wizards/new-rule';
+import newRule from '../../../../src/lib/cli/wizards/new-rule';
 
 test.serial('If newRule is not an option, it should return false', async (t) => {
-    const result = await rule.newRule({} as CLIOptions);
+    const result = await newRule({} as CLIOptions);
 
     t.false(result);
 });
@@ -53,7 +53,7 @@ test.serial('It creates a rule if the option multiple rules is false', async (t)
     sandbox.stub(process, 'cwd').returns(root);
     sandbox.stub(inquirer, 'prompt').resolves(results);
 
-    const result = await rule.newRule(actions);
+    const result = await newRule(actions);
 
     t.true(fsExtraCopyStub.args[0][0].endsWith('files'), 'Unexpected path for official files');
     t.is(fsExtraCopyStub.args[0][1], path.join(root, 'rule-awesome-rule'), 'Copy path is not the expected one');
@@ -104,7 +104,7 @@ test.serial('It creates a package with multiple rules', async (t) => {
         .onThirdCall()
         .resolves(rule2Results);
 
-    const result = await rule.newRule(actions);
+    const result = await newRule(actions);
 
     t.true(fsExtraCopyStub.args[0][0].endsWith('no-official-files'), 'Unexpected path for non official files');
     t.true(fsExtraCopyStub.args[1][0].endsWith('files'), 'Unexpected path for official files');

--- a/packages/sonarwhal/tests/lib/cli/wizards/new-rule.ts
+++ b/packages/sonarwhal/tests/lib/cli/wizards/new-rule.ts
@@ -3,10 +3,7 @@ import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import test from 'ava';
 
-import { CLIOptions } from '../../../../src/lib/types';
 import * as handlebarsUtils from '../../../../src/lib/utils/handlebars';
-
-const actions = ({ newRule: true } as CLIOptions);
 
 const inquirer = { prompt() { } };
 const misc = {
@@ -29,7 +26,7 @@ proxyquire('../../../../src/lib/cli/wizards/new-rule', {
 import newRule from '../../../../src/lib/cli/wizards/new-rule';
 
 test.serial('If newRule is not an option, it should return false', async (t) => {
-    const result = await newRule({} as CLIOptions);
+    const result = await newRule();
 
     t.false(result);
 });
@@ -53,7 +50,7 @@ test.serial('It creates a rule if the option multiple rules is false', async (t)
     sandbox.stub(process, 'cwd').returns(root);
     sandbox.stub(inquirer, 'prompt').resolves(results);
 
-    const result = await newRule(actions);
+    const result = await newRule();
 
     t.true(fsExtraCopyStub.args[0][0].endsWith('files'), 'Unexpected path for official files');
     t.is(fsExtraCopyStub.args[0][1], path.join(root, 'rule-awesome-rule'), 'Copy path is not the expected one');
@@ -104,7 +101,7 @@ test.serial('It creates a package with multiple rules', async (t) => {
         .onThirdCall()
         .resolves(rule2Results);
 
-    const result = await newRule(actions);
+    const result = await newRule();
 
     t.true(fsExtraCopyStub.args[0][0].endsWith('no-official-files'), 'Unexpected path for non official files');
     t.true(fsExtraCopyStub.args[1][0].endsWith('files'), 'Unexpected path for official files');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,6 +6066,10 @@ require-precompiled@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/require-precompiled/-/require-precompiled-0.1.0.tgz#5a1b52eb70ebed43eb982e974c85ab59571e56fa"
 
+require-so-slow@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require-so-slow/-/require-so-slow-1.0.1.tgz#af85685707f1fd86d62a6dbf20ff7efb538a0716"
+
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

Use dynamic imports to load the task the user has decided to execute so
there are less modules loaded directly and the memory footprint is
smaller.

- - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: https://github.com/sonarwhal/sonarwhal/issues/896#issuecomment-392114447

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
