### PR TITLE
New: Add rule to check stylesheet limits

### DIFF
--- a/packages/rule-stylesheet-limits/.npmrc
+++ b/packages/rule-stylesheet-limits/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/rule-stylesheet-limits/LICENSE.txt
+++ b/packages/rule-stylesheet-limits/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright JS Foundation and other contributors, https://js.foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/rule-stylesheet-limits/README.md
+++ b/packages/rule-stylesheet-limits/README.md
@@ -4,37 +4,28 @@ Checks if CSS exceeds known stylesheet limits.
 
 ## Why is this important?
 
-Internet Explorer prior to version 10 have limits on the
-number of CSS stylesheets, imports, and rules which are relatively small
-compared to modern browsers. Once these limits are exceeded, additional
-stylesheets, imports, and rules are ignored. Much larger limits exist in more
-recent versions that can also cause styles to be ignored if exceeded. For more
-details see [Stylesheet limits in Internet Explorer][stylesheet limits].
+Internet Explorer 9 and below has limits on the number of CSS stylesheets,
+imports, and rules which are relatively small compared to modern browsers.
+Once these limits are exceeded, additional stylesheets, imports, and rules
+are ignored. For more details see
+[Stylesheet limits in Internet Explorer][stylesheet limits].
 
 ## What does the rule check?
 
-When targeting versions of Internet Explorer less than 10, this rule checks if
+When targeting versions of Internet Explorer 9 and below, this rule checks if
 one of the following [limits][stylesheet limits] is exceeded:
 
 * 4095 rules
 * 31 stylesheets
 * 4 levels of imports
 
-When targeting modern browsers, this rule checks if one of the following
-[limits in Internet Explorer 10+][stylesheet limits] is exceeded:
-
-* 65535 rules
-* 4095 stylesheets
-
 ### Examples that **trigger** the rule
 
 * A page targeting Internet Explorer 9 containing 4096 or more CSS rules
-* A page targeting Internet Explorer 10 containing 65535 or more CSS rules
 
 ### Examples that **pass** the rule
 
 * A page targeting Internet Explorer 9 with fewer than 4096 CSS rules
-* A page targeting Internet Explorer 10 and up with fewer than 65535 rules
 
 ## Can the rule be configured?
 

--- a/packages/rule-stylesheet-limits/README.md
+++ b/packages/rule-stylesheet-limits/README.md
@@ -1,59 +1,40 @@
 # stylesheet-limits (`@sonarwhal/rule-stylesheet-limits`)
 
-Checks if CSS exceeds known stylesheet limits
+Checks if CSS exceeds known stylesheet limits.
 
 ## Why is this important?
 
-IE versions prior to IE 10 have limits on the number of CSS stylesheets, imports, and rules which are relatively small compared to modern browsers. Once these limits are exceeded, additional stylesheets, imports, and rules are ignored. Much larger limits exist in more recent versions, but can also cause styles to be ignored if exceeded. For more details see [Stylesheet limits in Internet Explorer][stylesheet limits].
-
-## How to use this rule?
-
-To use it you will have to install it via `npm`:
-
-```bash
-npm install @sonarwhal/rule-stylesheet-limits
-```
-
-Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
-parameter, or to install it globally, you can use the `-g` parameter. For
-other options see
-[`npm`'s documentation](https://docs.npmjs.com/cli/install).
-
-And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
-configuration file:
-
-```json
-{
-    "connector": {...},
-    "formatters": [...],
-    "parsers": [...],
-    "rules": {
-        "stylesheet-limits": "error"
-    },
-    ...
-}
-```
+Internet Explorer versions prior to Internet Explorer 10 have limits on the
+number of CSS stylesheets, imports, and rules which are relatively small
+compared to modern browsers. Once these limits are exceeded, additional
+stylesheets, imports, and rules are ignored. Much larger limits exist in more
+recent versions, but can also cause styles to be ignored if exceeded. For more
+details see [Stylesheet limits in Internet Explorer][stylesheet limits].
 
 ## What does the rule check?
 
-When targeting versions of IE less than 10, this rule checks if one of the following limits is exceeded:
+When targeting versions of Internet Explorer less than 10, this rule checks if
+one of the following limits is exceeded:
+
 * 4095 rules
 * 31 stylesheets
 * 4 levels of imports
 
-When targeting modern browsers, this rule checks if one of the following limits in IE10+ is exceeded:
+When targeting modern browsers, this rule checks if one of the following
+limits in Internet Explorer 10+ is exceeded:
+
 * 65535 rules
 * 4095 stylesheets
 
 ### Examples that **trigger** the rule
 
-* A page targeting IE 9 containing 4096 or more CSS rules
-* A page targeting IE 10 containing 65535 or more CSS rules
+* A page targeting Internet Explorer 9 containing 4096 or more CSS rules
+* A page targeting Internet Explorer 10 containing 65535 or more CSS rules
 
 ### Examples that **pass** the rule
 
-* A page targeting IE 9 with fewer than 4096 CSS rules
-* A page targeting browsers newer than IE 9 with fewer than 65534 rules
+* A page targeting Internet Explorer 9 with fewer than 4096 CSS rules
+* A page targeting Internet Explorer 10 and up with fewer than 65534 rules
 
 ## Can the rule be configured?
 
@@ -78,7 +59,34 @@ In the [`.sonarwhalrc`][sonarwhalrc] file:
 }
 ```
 
-## Further Reading
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-stylesheet-limits
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "stylesheet-limits": "error",
+        ...
+    },
+    ...
+}
+```
 
 <!-- Link labels: -->
 

--- a/packages/rule-stylesheet-limits/README.md
+++ b/packages/rule-stylesheet-limits/README.md
@@ -1,0 +1,81 @@
+# stylesheet-limits (`@sonarwhal/rule-stylesheet-limits`)
+
+Checks if CSS exceeds known stylesheet limits
+
+## Why is this important?
+
+IE versions prior to IE 10 have limits on the number of CSS stylesheets, imports, and rules which are relatively small compared to modern browsers. Once these limits are exceeded, additional stylesheets, imports, and rules are ignored. Much larger limits exist in more recent versions, but can also cause styles to be ignored if exceeded. For more details see [Stylesheet limits in Internet Explorer][stylesheet limits].
+
+## How to use this rule?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @sonarwhal/rule-stylesheet-limits
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.sonarwhalrc`][sonarwhalrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "rules": {
+        "stylesheet-limits": "error"
+    },
+    ...
+}
+```
+
+## What does the rule check?
+
+When targeting versions of IE less than 10, this rule checks if one of the following limit is exceeded:
+* 4095 rules
+
+When targeting modern browsers, this rule checks if one of the following limit in IE10+ is exceeded:
+* 65535 rules
+
+### Examples that **trigger** the rule
+
+* A page targeting IE 9 containing 4096 or more CSS rules
+* A page targeting IE 10 containing 65535 or more CSS rules
+
+### Examples that **pass** the rule
+
+* A page targeting IE 9 with fewer than 4096 CSS rules
+* A page targeting browsers newer than IE 9 with fewer than 65534 rules
+
+## Can the rule be configured?
+
+You can overwrite the defaults by specifying custom values for the
+number of CSS rules to allow.
+
+In the [`.sonarwhalrc`][sonarwhalrc] file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "rules": {
+        "stylesheet-limit": ["error", {
+            "max-css-rules": 1000
+        }],
+        ...
+    },
+    ...
+}
+```
+
+## Further Reading
+
+<!-- Link labels: -->
+
+[sonarwhalrc]: https://sonarwhal.com/docs/user-guide/further-configuration/sonarwhalrc-formats/
+[stylesheet limits]: https://blogs.msdn.microsoft.com/ieinternals/2011/05/14/stylesheet-limits-in-internet-explorer/

--- a/packages/rule-stylesheet-limits/README.md
+++ b/packages/rule-stylesheet-limits/README.md
@@ -4,11 +4,11 @@ Checks if CSS exceeds known stylesheet limits.
 
 ## Why is this important?
 
-Internet Explorer versions prior to Internet Explorer 10 have limits on the
+Internet Explorer prior to version 10 have limits on the
 number of CSS stylesheets, imports, and rules which are relatively small
 compared to modern browsers. Once these limits are exceeded, additional
 stylesheets, imports, and rules are ignored. Much larger limits exist in more
-recent versions, but can also cause styles to be ignored if exceeded. For more
+recent versions that can also cause styles to be ignored if exceeded. For more
 details see [Stylesheet limits in Internet Explorer][stylesheet limits].
 
 ## What does the rule check?

--- a/packages/rule-stylesheet-limits/README.md
+++ b/packages/rule-stylesheet-limits/README.md
@@ -4,11 +4,19 @@ Checks if CSS exceeds known stylesheet limits.
 
 ## Why is this important?
 
-Internet Explorer 9 and below has limits on the number of CSS stylesheets,
+Internet Explorer 9 and below have limits on the number of CSS stylesheets,
 imports, and rules which are relatively small compared to modern browsers.
 Once these limits are exceeded, additional stylesheets, imports, and rules
 are ignored. For more details see
-[Stylesheet limits in Internet Explorer][stylesheet limits].
+[_"Stylesheet limits in Internet Explorer"_][stylesheet limits].
+
+Similar behavior existed in older versions of other browsers, such as
+[Chrome][chrome limits]. Newer browsers have much higher limits such as
+65535 rules in [Internet Explorer 10+ and Edge][stylesheet limits].
+
+Even in modern browsers large numbers of CSS selectors can negatively impact
+performance. You [can customize](#can-the-rule-be-configured) this rule and
+set appropriate limits for your project or team.
 
 ## What does the rule check?
 
@@ -32,7 +40,8 @@ one of the following [limits][stylesheet limits] is exceeded:
 ## Can the rule be configured?
 
 You can overwrite the defaults by specifying custom values for the
-number of CSS rules to allow.
+number of CSS rules to allow. Note if the custom values are above
+the default values, the default values will still be used.
 
 In the [`.sonarwhalrc`][sonarwhalrc] file:
 
@@ -85,3 +94,4 @@ configuration file:
 
 [sonarwhalrc]: https://sonarwhal.com/docs/user-guide/further-configuration/sonarwhalrc-formats/
 [stylesheet limits]: https://blogs.msdn.microsoft.com/ieinternals/2011/05/14/stylesheet-limits-in-internet-explorer/
+[chrome limits]: https://stackoverflow.com/questions/20828995/how-long-can-a-css-selector-be]

--- a/packages/rule-stylesheet-limits/README.md
+++ b/packages/rule-stylesheet-limits/README.md
@@ -26,6 +26,8 @@ one of the following [limits][stylesheet limits] is exceeded:
 ### Examples that **pass** the rule
 
 * A page targeting Internet Explorer 9 with fewer than 4096 CSS rules
+* A page not targeting Internet Explorer 9 or below regardless of the number
+  of CSS rules
 
 ## Can the rule be configured?
 

--- a/packages/rule-stylesheet-limits/README.md
+++ b/packages/rule-stylesheet-limits/README.md
@@ -36,11 +36,14 @@ configuration file:
 
 ## What does the rule check?
 
-When targeting versions of IE less than 10, this rule checks if one of the following limit is exceeded:
+When targeting versions of IE less than 10, this rule checks if one of the following limits is exceeded:
 * 4095 rules
+* 31 stylesheets
+* 4 levels of imports
 
-When targeting modern browsers, this rule checks if one of the following limit in IE10+ is exceeded:
+When targeting modern browsers, this rule checks if one of the following limits in IE10+ is exceeded:
 * 65535 rules
+* 4095 stylesheets
 
 ### Examples that **trigger** the rule
 
@@ -65,7 +68,9 @@ In the [`.sonarwhalrc`][sonarwhalrc] file:
     "formatters": [...],
     "rules": {
         "stylesheet-limit": ["error", {
-            "max-css-rules": 1000
+            "maxRules": 1000,
+            "maxSheets": 10,
+            "maxImports": 2
         }],
         ...
     },

--- a/packages/rule-stylesheet-limits/README.md
+++ b/packages/rule-stylesheet-limits/README.md
@@ -1,4 +1,4 @@
-# stylesheet-limits (`@sonarwhal/rule-stylesheet-limits`)
+# Avoid exceeding CSS stylesheet limits (`@sonarwhal/rule-stylesheet-limits`)
 
 Checks if CSS exceeds known stylesheet limits.
 
@@ -14,14 +14,14 @@ details see [Stylesheet limits in Internet Explorer][stylesheet limits].
 ## What does the rule check?
 
 When targeting versions of Internet Explorer less than 10, this rule checks if
-one of the following limits is exceeded:
+one of the following [limits][stylesheet limits] is exceeded:
 
 * 4095 rules
 * 31 stylesheets
 * 4 levels of imports
 
 When targeting modern browsers, this rule checks if one of the following
-limits in Internet Explorer 10+ is exceeded:
+[limits in Internet Explorer 10+][stylesheet limits] is exceeded:
 
 * 65535 rules
 * 4095 stylesheets
@@ -34,7 +34,7 @@ limits in Internet Explorer 10+ is exceeded:
 ### Examples that **pass** the rule
 
 * A page targeting Internet Explorer 9 with fewer than 4096 CSS rules
-* A page targeting Internet Explorer 10 and up with fewer than 65534 rules
+* A page targeting Internet Explorer 10 and up with fewer than 65535 rules
 
 ## Can the rule be configured?
 

--- a/packages/rule-stylesheet-limits/package.json
+++ b/packages/rule-stylesheet-limits/package.json
@@ -20,7 +20,7 @@
     "npm-run-all": "^4.1.2",
     "nyc": "^11.7.1",
     "rimraf": "^2.6.2",
-    "sonarwhal": "^1.9.0",
+    "sonarwhal": "^1.10.0",
     "typescript": "^2.8.3",
     "typescript-eslint-parser": "^15.0.0"
   },
@@ -45,7 +45,7 @@
     "extends": "../../.nycrc"
   },
   "peerDependencies": {
-    "sonarwhal": "^1.9.0"
+    "sonarwhal": "^1.10.0"
   },
   "private": true,
   "repository": "sonarwhal/sonarwhal",

--- a/packages/rule-stylesheet-limits/package.json
+++ b/packages/rule-stylesheet-limits/package.json
@@ -1,0 +1,70 @@
+{
+  "ava": {
+    "failFast": false,
+    "files": [
+      "dist/tests/**/*.js"
+    ],
+    "timeout": "1m"
+  },
+  "description": "Checks if CSS exceeds known stylesheet limits",
+  "devDependencies": {
+    "@types/debug": "0.0.30",
+    "@types/node": "8.0.14",
+    "ava": "^0.25.0",
+    "cpx": "^1.5.0",
+    "eslint": "^4.19.1",
+    "eslint-plugin-markdown": "^1.0.0-beta.7",
+    "eslint-plugin-typescript": "^0.12.0",
+    "markdownlint-cli": "^0.8.1",
+    "npm-link-check": "^2.0.0",
+    "npm-run-all": "^4.1.2",
+    "nyc": "^11.7.1",
+    "rimraf": "^2.6.2",
+    "sonarwhal": "^1.9.0",
+    "typescript": "^2.8.3",
+    "typescript-eslint-parser": "^15.0.0"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "files": [
+    "dist/src",
+    "npm-shrinkwrap.json"
+  ],
+  "homepage": "https://sonarwhal.com/",
+  "keywords": [
+    "rule",
+    "sonarwhal",
+    "stylesheet-limits",
+    "stylesheet-limits-rule"
+  ],
+  "license": "Apache-2.0",
+  "main": "dist/src/rule.js",
+  "name": "@sonarwhal/rule-stylesheet-limits",
+  "nyc": {
+    "extends": "../../.nycrc"
+  },
+  "peerDependencies": {
+    "sonarwhal": "^1.9.0"
+  },
+  "private": true,
+  "repository": "sonarwhal/sonarwhal",
+  "scripts": {
+    "build": "npm run clean && npm-run-all build:*",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
+    "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
+    "build:ts": "tsc",
+    "clean": "rimraf dist",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",
+    "lint:md": "markdownlint --ignore CHANGELOG.md *.md",
+    "sonarwhal": "node node_modules/sonarwhal/dist/src/bin/sonarwhal.js",
+    "test": "npm run lint && npm run build && nyc ava",
+    "init": "npm install && npm run build",
+    "watch": "npm run build && npm-run-all --parallel -c watch:*",
+    "watch:assets": "npm run build:assets -- -w --no-initial",
+    "watch:test": "ava --watch",
+    "watch:ts": "npm run build:ts -- --watch"
+  },
+  "version": "1.0.0"
+}

--- a/packages/rule-stylesheet-limits/src/rule.ts
+++ b/packages/rule-stylesheet-limits/src/rule.ts
@@ -4,7 +4,7 @@
 
 import { Category } from 'sonarwhal/dist/src/lib/enums/category';
 import { RuleContext } from 'sonarwhal/dist/src/lib/rule-context';
-import { IRule, RuleMetadata } from 'sonarwhal/dist/src/lib/types';
+import { IRule, RuleMetadata, ScanEnd } from 'sonarwhal/dist/src/lib/types';
 import { debug as d } from 'sonarwhal/dist/src/lib/utils/debug';
 import { RuleScope } from 'sonarwhal/dist/src/lib/enums/rulescope';
 
@@ -153,7 +153,7 @@ export default class StylesheetLimitsRule implements IRule {
             return combinedResults;
         };
 
-        const validateScanEnd = async () => {
+        const validateScanEnd = async (event: ScanEnd) => {
 
             const results = await context.evaluate(`(${injectedCode})()`);
 
@@ -161,15 +161,15 @@ export default class StylesheetLimitsRule implements IRule {
 
             // Only check `maxImports` if a limit has been specified
             if (hasImportLimit && results.imports >= maxImports) {
-                context.report(null, null, `Maximum of ${maxImports} nested imports reached (${results.imports})`);
+                await context.report(event.resource, null, `Maximum of ${maxImports} nested imports reached (${results.imports})`);
             }
 
             if (hasRuleLimit && results.rules >= maxRules) {
-                context.report(null, null, `Maximum of ${maxRules} CSS rules reached (${results.rules})`);
+                await context.report(event.resource, null, `Maximum of ${maxRules} CSS rules reached (${results.rules})`);
             }
 
             if (hasSheetLimit && results.sheets >= maxSheets) {
-                context.report(null, null, `Maximum of ${maxSheets} stylesheets reached (${results.sheets})`);
+                await context.report(event.resource, null, `Maximum of ${maxSheets} stylesheets reached (${results.sheets})`);
             }
         };
 

--- a/packages/rule-stylesheet-limits/src/rule.ts
+++ b/packages/rule-stylesheet-limits/src/rule.ts
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Checks if CSS exceeds known stylesheet limits
+ */
+
+import { Category } from 'sonarwhal/dist/src/lib/enums/category';
+import { RuleContext } from 'sonarwhal/dist/src/lib/rule-context';
+// The list of types depends on the events you want to capture.
+import { IRule, ScanEnd, RuleMetadata } from 'sonarwhal/dist/src/lib/types';
+import { debug as d } from 'sonarwhal/dist/src/lib/utils/debug';
+import { RuleScope } from 'sonarwhal/dist/src/lib/enums/rulescope';
+
+const debug: debug.IDebugger = d(__filename);
+
+/*
+ * ------------------------------------------------------------------------------
+ * Public
+ * ------------------------------------------------------------------------------
+ */
+
+export default class StylesheetLimitsRule implements IRule {
+
+    public static readonly meta: RuleMetadata = {
+        docs: {
+            category: Category.interoperability,
+            description: `Checks if CSS exceeds known stylesheet limits`
+        },
+        id: 'stylesheet-limits',
+        schema: [
+            /*
+             * If you want to allow the user to configure your rule
+             * you should use a valid JSON schema. More info in:
+             * https://sonarwhal.com/docs/contributor-guide/rules/#themetaproperty
+             */
+        ],
+        scope: RuleScope.any
+    }
+
+    public constructor(context: RuleContext) {
+
+        let maxRules = context.targetedBrowsers.includes('ie 9') ? 4095 : 65534;
+
+        if (context.ruleOptions && context.ruleOptions['max-css-rules'])
+            maxRules = context.ruleOptions['max-css-rules'];
+
+        //  this function will be evaluated in the context of the page
+        const injectedCode = function() {
+
+            //  helper function to recursively count rules in stylesheets
+            const countRules = (styleSheet: CSSStyleSheet) => {
+
+                try {
+
+                    //  count rules in this stylesheet
+                    return Array.from(styleSheet.cssRules).reduce((count, rule) => {
+
+                        //  count each selector in a style rule separately
+                        if (rule instanceof CSSStyleRule)
+                            return count + rule.selectorText.split(',').length;
+
+                        //  recursively count rules in imported stylesheets
+                        if (rule instanceof CSSImportRule)
+                            return count + countRules(rule.styleSheet) + 1;
+
+                        //  other rules count as one each
+                        return count + 1;
+
+                    }, 0);
+
+                } catch(e) {
+
+                    //  accessing cssRules of a cross-origin stylesheet can throw
+                    //  if this happens, exclude the stylesheet from the count
+                    return 0;
+
+                }
+            };
+
+            //  get the recursive count of rules for all stylesheets in the page
+            return Array.from(document.styleSheets)
+                .map(countRules)
+                .reduce((a, b) => a + b, 0);
+        };
+
+        const validateScanEnd = async (scanEnd: ScanEnd) => {
+
+            const totalRules = await context.evaluate(`(${injectedCode})()`);
+
+            //  report if we hit the limit to support flagging on platforms which will drop subsequent rules
+            if (totalRules >= maxRules) {
+                context.report(null, null, `Maximum of ${maxRules} CSS rules reached (${totalRules})`);
+            }
+
+            return;
+        };
+
+        context.on('scan::end', validateScanEnd);
+    }
+}

--- a/packages/rule-stylesheet-limits/src/rule.ts
+++ b/packages/rule-stylesheet-limits/src/rule.ts
@@ -26,14 +26,20 @@ export default class StylesheetLimitsRule implements IRule {
         id: 'stylesheet-limits',
         schema: [{
             additionalProperties: false,
+            definitions: {
+                number: {
+                    minimum: 0,
+                    type: 'integer'
+                }
+            },
             properties: {
-                maxImports: { type: 'number' },
-                maxRules: { type: 'number' },
-                maxSheets: { type: 'number' }
+                maxImports: { $ref: '#/definitions/number' },
+                maxRules: { $ref: '#/definitions/number' },
+                maxSheets: { $ref: '#/definitions/number' }
             },
             type: ['object', 'null']
         }],
-        scope: RuleScope.any
+        scope: RuleScope.site
     }
 
     public constructor(context: RuleContext) {
@@ -47,7 +53,9 @@ export default class StylesheetLimitsRule implements IRule {
         // Allow limits to be overridden by rule options.
         const options = context.ruleOptions;
 
+        // Min the default/options values to ensure overrides can't "hide" browser limits
         if (options) {
+            // Always use the options value if no default is specified (maxImports === 0)
             if (options.maxImports && (maxImports === 0 || options.maxImports < maxImports)) {
                 maxImports = options.maxImports;
             }
@@ -55,7 +63,7 @@ export default class StylesheetLimitsRule implements IRule {
                 maxRules = options.maxRules;
             }
             if (options.maxSheets && options.maxSheets < maxSheets) {
-                maxSheets =options.maxSheets;
+                maxSheets = options.maxSheets;
             }
         }
 
@@ -135,6 +143,7 @@ export default class StylesheetLimitsRule implements IRule {
 
             // Report once we hit a limit to support flagging on platforms which will drop subsequent rules.
 
+            // Only check `maxImports` if a limit has been specified (is non-zero)
             if (maxImports && results.imports >= maxImports) {
                 context.report(null, null, `Maximum of ${maxImports} nested imports reached (${results.imports})`);
             }

--- a/packages/rule-stylesheet-limits/src/rule.ts
+++ b/packages/rule-stylesheet-limits/src/rule.ts
@@ -1,11 +1,10 @@
 /**
- * @fileoverview Checks if CSS exceeds known stylesheet limits
+ * @fileoverview Checks if CSS exceeds known stylesheet limits.
  */
 
 import { Category } from 'sonarwhal/dist/src/lib/enums/category';
 import { RuleContext } from 'sonarwhal/dist/src/lib/rule-context';
-// The list of types depends on the events you want to capture.
-import { IRule, ScanEnd, RuleMetadata } from 'sonarwhal/dist/src/lib/types';
+import { IRule, RuleMetadata } from 'sonarwhal/dist/src/lib/types';
 import { debug as d } from 'sonarwhal/dist/src/lib/utils/debug';
 import { RuleScope } from 'sonarwhal/dist/src/lib/enums/rulescope';
 
@@ -22,15 +21,15 @@ export default class StylesheetLimitsRule implements IRule {
     public static readonly meta: RuleMetadata = {
         docs: {
             category: Category.interoperability,
-            description: `Checks if CSS exceeds known stylesheet limits`
+            description: `Checks if CSS exceeds known stylesheet limits.`
         },
         id: 'stylesheet-limits',
         schema: [{
             additionalProperties: false,
             properties: {
+                maxImports: { type: 'number' },
                 maxRules: { type: 'number' },
-                maxSheets: { type: 'number' },
-                maxImports: { type: 'number' }
+                maxSheets: { type: 'number' }
             },
             type: ['object', 'null']
         }],
@@ -41,99 +40,112 @@ export default class StylesheetLimitsRule implements IRule {
 
         const includesIE9 = context.targetedBrowsers.includes('ie 9');
 
+        let maxImports = includesIE9 ? 4 : 0;
         let maxRules = includesIE9 ? 4095 : 65534;
         let maxSheets = includesIE9 ? 31 : 4095;
-        let maxImports = includesIE9 ? 4 : 0;
 
-        //  allow limits to be overridden by rule options
-        if (context.ruleOptions) {
-            maxRules = context.ruleOptions.maxRules || maxRules;
-            maxSheets = context.ruleOptions.maxSheets || maxSheets;
-            maxImports = context.ruleOptions.maxImports || maxImports;
+        // Allow limits to be overridden by rule options.
+        const options = context.ruleOptions;
+
+        if (options) {
+            if (options.maxImports && (maxImports === 0 || options.maxImports < maxImports)) {
+                maxImports = options.maxImports;
+            }
+            if (options.maxRules && options.maxRules < maxRules) {
+                maxRules = options.maxRules;
+            }
+            if (options.maxSheets && options.maxSheets < maxSheets) {
+                maxSheets =options.maxSheets;
+            }
         }
 
-        //  this function will be evaluated in the context of the page
+        // The following function will be evaluated in the context of the page.
         const injectedCode = function() {
 
-            //  helper function to recursively count rules in stylesheets
+            // Recursively count rules and imports in the passed stylesheet.
             const countRules = (styleSheet: CSSStyleSheet) => {
 
                 const results = {
+                    imports: 0,
                     rules: 0,
-                    sheets: 1,
-                    imports: 0
+                    sheets: 1
                 };
 
                 try {
 
-                    //  count rules in this stylesheet
-                    Array.from(styleSheet.cssRules).forEach(rule => {
+                    // Count rules in this stylesheet.
+                    Array.from(styleSheet.cssRules).forEach((rule) => {
 
                         if (rule instanceof CSSStyleRule) {
 
-                            //  count each selector in a style rule separately
+                            // Count each selector in a style rule separately.
                             results.rules += rule.selectorText.split(',').length;
 
                         } else if (rule instanceof CSSImportRule) {
 
-                            //  recursively count rules in imported stylesheets
+                            // Recursively count rules in imported stylesheets.
                             const subResults = countRules(rule.styleSheet);
+
+                            results.imports += Math.max(results.imports, subResults.imports + 1);
                             results.rules += subResults.rules + 1;
                             results.sheets += subResults.sheets;
-                            results.imports += Math.max(results.imports, subResults.imports + 1);
 
                         } else {
 
-                            //  other rules count as one each
+                            // Other rules count as one each.
                             results.rules += 1;
 
                         }
                     });
 
-                } catch(e) {
+                } catch (e) {
 
-                    //  accessing cssRules of a cross-origin stylesheet can throw
-                    //  if this happens, exclude the stylesheet from the count
-
+                    /*
+                     * Accessing cssRules of a cross-origin stylesheet can throw.
+                     * If this happens, exclude the stylesheet from the count.
+                     */
                 }
 
                 return results;
             };
 
             const combinedResults = {
+                imports: 0,
                 rules: 0,
-                sheets: 0,
-                imports: 0
+                sheets: 0
             };
 
-            //  get the recursive count of rules for all stylesheets in the page
-            Array.from(document.styleSheets).forEach(sheet => {
+            // Get the recursive count of rules for all stylesheets in the page.
+            Array.from(document.styleSheets).forEach((sheet) => {
                 if (sheet instanceof CSSStyleSheet) {
                     const subResults = countRules(sheet);
+
+                    combinedResults.imports += Math.max(combinedResults.imports, subResults.imports);
                     combinedResults.rules += subResults.rules;
                     combinedResults.sheets += subResults.sheets;
-                    combinedResults.imports += Math.max(combinedResults.imports, subResults.imports);
                 }
             });
 
             return combinedResults;
         };
 
-        const validateScanEnd = async (scanEnd: ScanEnd) => {
+        const validateScanEnd = async () => {
 
             const results = await context.evaluate(`(${injectedCode})()`);
 
-            //  report once we hit a limit to support flagging on platforms which will drop subsequent rules
+            // Report once we hit a limit to support flagging on platforms which will drop subsequent rules.
 
-            if (results.rules >= maxRules)
-                context.report(null, null, `Maximum of ${maxRules} CSS rules reached (${results.rules})`);
-
-            if (results.sheets >= maxSheets)
-                context.report(null, null, `Maximum of ${maxSheets} stylesheets reached (${results.sheets})`);
-
-            if (maxImports && results.imports >= maxImports)
+            if (maxImports && results.imports >= maxImports) {
                 context.report(null, null, `Maximum of ${maxImports} nested imports reached (${results.imports})`);
+            }
 
+            if (results.rules >= maxRules) {
+                context.report(null, null, `Maximum of ${maxRules} CSS rules reached (${results.rules})`);
+            }
+
+            if (results.sheets >= maxSheets) {
+                context.report(null, null, `Maximum of ${maxSheets} stylesheets reached (${results.sheets})`);
+            }
         };
 
         context.on('scan::end', validateScanEnd);

--- a/packages/rule-stylesheet-limits/src/rule.ts
+++ b/packages/rule-stylesheet-limits/src/rule.ts
@@ -25,22 +25,32 @@ export default class StylesheetLimitsRule implements IRule {
             description: `Checks if CSS exceeds known stylesheet limits`
         },
         id: 'stylesheet-limits',
-        schema: [
-            /*
-             * If you want to allow the user to configure your rule
-             * you should use a valid JSON schema. More info in:
-             * https://sonarwhal.com/docs/contributor-guide/rules/#themetaproperty
-             */
-        ],
+        schema: [{
+            additionalProperties: false,
+            properties: {
+                maxRules: { type: 'number' },
+                maxSheets: { type: 'number' },
+                maxImports: { type: 'number' }
+            },
+            type: ['object', 'null']
+        }],
         scope: RuleScope.any
     }
 
     public constructor(context: RuleContext) {
 
-        let maxRules = context.targetedBrowsers.includes('ie 9') ? 4095 : 65534;
+        const includesIE9 = context.targetedBrowsers.includes('ie 9');
 
-        if (context.ruleOptions && context.ruleOptions['max-css-rules'])
-            maxRules = context.ruleOptions['max-css-rules'];
+        let maxRules = includesIE9 ? 4095 : 65534;
+        let maxSheets = includesIE9 ? 31 : 4095;
+        let maxImports = includesIE9 ? 4 : 0;
+
+        //  allow limits to be overridden by rule options
+        if (context.ruleOptions) {
+            maxRules = context.ruleOptions.maxRules || maxRules;
+            maxSheets = context.ruleOptions.maxSheets || maxSheets;
+            maxImports = context.ruleOptions.maxImports || maxImports;
+        }
 
         //  this function will be evaluated in the context of the page
         const injectedCode = function() {
@@ -48,49 +58,82 @@ export default class StylesheetLimitsRule implements IRule {
             //  helper function to recursively count rules in stylesheets
             const countRules = (styleSheet: CSSStyleSheet) => {
 
+                const results = {
+                    rules: 0,
+                    sheets: 1,
+                    imports: 0
+                };
+
                 try {
 
                     //  count rules in this stylesheet
-                    return Array.from(styleSheet.cssRules).reduce((count, rule) => {
+                    Array.from(styleSheet.cssRules).forEach(rule => {
 
-                        //  count each selector in a style rule separately
-                        if (rule instanceof CSSStyleRule)
-                            return count + rule.selectorText.split(',').length;
+                        if (rule instanceof CSSStyleRule) {
 
-                        //  recursively count rules in imported stylesheets
-                        if (rule instanceof CSSImportRule)
-                            return count + countRules(rule.styleSheet) + 1;
+                            //  count each selector in a style rule separately
+                            results.rules += rule.selectorText.split(',').length;
 
-                        //  other rules count as one each
-                        return count + 1;
+                        } else if (rule instanceof CSSImportRule) {
 
-                    }, 0);
+                            //  recursively count rules in imported stylesheets
+                            const subResults = countRules(rule.styleSheet);
+                            results.rules += subResults.rules + 1;
+                            results.sheets += subResults.sheets;
+                            results.imports += Math.max(results.imports, subResults.imports + 1);
+
+                        } else {
+
+                            //  other rules count as one each
+                            results.rules += 1;
+
+                        }
+                    });
 
                 } catch(e) {
 
                     //  accessing cssRules of a cross-origin stylesheet can throw
                     //  if this happens, exclude the stylesheet from the count
-                    return 0;
 
                 }
+
+                return results;
+            };
+
+            const combinedResults = {
+                rules: 0,
+                sheets: 0,
+                imports: 0
             };
 
             //  get the recursive count of rules for all stylesheets in the page
-            return Array.from(document.styleSheets)
-                .map(countRules)
-                .reduce((a, b) => a + b, 0);
+            Array.from(document.styleSheets).forEach(sheet => {
+                if (sheet instanceof CSSStyleSheet) {
+                    const subResults = countRules(sheet);
+                    combinedResults.rules += subResults.rules;
+                    combinedResults.sheets += subResults.sheets;
+                    combinedResults.imports += Math.max(combinedResults.imports, subResults.imports);
+                }
+            });
+
+            return combinedResults;
         };
 
         const validateScanEnd = async (scanEnd: ScanEnd) => {
 
-            const totalRules = await context.evaluate(`(${injectedCode})()`);
+            const results = await context.evaluate(`(${injectedCode})()`);
 
-            //  report if we hit the limit to support flagging on platforms which will drop subsequent rules
-            if (totalRules >= maxRules) {
-                context.report(null, null, `Maximum of ${maxRules} CSS rules reached (${totalRules})`);
-            }
+            //  report once we hit a limit to support flagging on platforms which will drop subsequent rules
 
-            return;
+            if (results.rules >= maxRules)
+                context.report(null, null, `Maximum of ${maxRules} CSS rules reached (${results.rules})`);
+
+            if (results.sheets >= maxSheets)
+                context.report(null, null, `Maximum of ${maxSheets} stylesheets reached (${results.sheets})`);
+
+            if (maxImports && results.imports >= maxImports)
+                context.report(null, null, `Maximum of ${maxImports} nested imports reached (${results.imports})`);
+
         };
 
         context.on('scan::end', validateScanEnd);

--- a/packages/rule-stylesheet-limits/src/rule.ts
+++ b/packages/rule-stylesheet-limits/src/rule.ts
@@ -82,6 +82,7 @@ export default class StylesheetLimitsRule implements IRule {
             }
         }
 
+        /* istanbul ignore next */
         // The following function will be evaluated in the context of the page.
         const injectedCode = function() {
 

--- a/packages/rule-stylesheet-limits/tests/tests.ts
+++ b/packages/rule-stylesheet-limits/tests/tests.ts
@@ -1,7 +1,8 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
+import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = 'stylesheet-limits';
+const ruleName = getRuleName(__dirname);
 
 const generateCSSRules = (count = 1) => {
     const rules = [];
@@ -24,7 +25,7 @@ const generateStyleSheets = (count = 1) => {
 };
 
 const generateImports = (count = 1) => {
-    const config = { '/': generateHTMLPage(`<style>@import url('i1.css');</style>`) };
+    const config: any = { '/': generateHTMLPage(`<style>@import url('i1.css');</style>`) };
 
     for (let i = 1; i <= count; i++) {
         config[`/i${i}.css`] = {
@@ -36,7 +37,7 @@ const generateImports = (count = 1) => {
     return config;
 };
 
-const test = (label, limits: { maxRules: number, maxSheets: number, maxImports: number }, configs: any) => {
+const test = (label: string, limits: { maxRules: number, maxSheets: number, maxImports: number }, configs: any) => {
     const { maxRules, maxSheets, maxImports } = limits;
 
     ruleRunner.testRule(ruleName, [

--- a/packages/rule-stylesheet-limits/tests/tests.ts
+++ b/packages/rule-stylesheet-limits/tests/tests.ts
@@ -61,6 +61,12 @@ const test = (label, limits: { maxRules: number, maxSheets: number, maxImports: 
     ], configs);
 
     if (maxImports) {
+        /*
+         * Exclude `jsdom` since it currently ignores `@import` rules.
+         * https://github.com/jsdom/jsdom/issues/2124
+         */
+        configs.ignoredConnectors = ['jsdom'];
+
         ruleRunner.testRule(ruleName, [
             {
                 name: `Page${label} contains less than ${maxImports} nested imports`,
@@ -71,12 +77,7 @@ const test = (label, limits: { maxRules: number, maxSheets: number, maxImports: 
                 reports: [{ message: `Maximum of ${maxImports} nested imports reached (${maxImports})` }],
                 serverConfig: generateImports(maxImports)
             }
-
-        /*
-         * Exclude `jsdom` since it currently ignores `@import` rules.
-         * https://github.com/jsdom/jsdom/issues/2124
-         */
-        ], { ...configs, ignoredConnectors: ['jsdom'] });
+        ], configs);
     }
 };
 

--- a/packages/rule-stylesheet-limits/tests/tests.ts
+++ b/packages/rule-stylesheet-limits/tests/tests.ts
@@ -1,40 +1,43 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
 const ruleName = 'stylesheet-limits';
 
 const generateCSSRules = (count = 1) => {
-    let rules = [];
+    const rules = [];
+
     for (let i = 1; i <= count; i++) {
         rules.push(`.r${i}`);
     }
-    return rules.join(',') + ' { color: #fff }';
+
+    return `${rules.join(',')} { color: #fff }`;
 };
 
 const generateStyleSheets = (count = 1) => {
-    let sheets = [];
+    const sheets = [];
+
     for (let i = 1; i <= count; i++) {
         sheets.push('<style>.r { color: #fff }</style>');
     }
+
     return sheets.join('\n');
 };
 
 const generateImports = (count = 1) => {
-    const config = {
-        '/': generateHTMLPage(`<style>@import url('i1.css');</style>`)
-    }
+    const config = { '/': generateHTMLPage(`<style>@import url('i1.css');</style>`) };
+
     for (let i = 1; i <= count; i++) {
         config[`/i${i}.css`] = {
             content: i < count ? `@import url('i${i + 1}.css');\n.r { color: #fff }` : '.r { color: #fff }',
             headers: { 'Content-Type': 'text/css' }
-        }
+        };
     }
-    return config;
-}
 
-function test(label, limits: { maxRules: number, maxSheets: number, maxImports: number }, configs: any) {
-    let { maxRules, maxSheets, maxImports } = limits;
+    return config;
+};
+
+const test = (label, limits: { maxRules: number, maxSheets: number, maxImports: number }, configs: any) => {
+    const { maxRules, maxSheets, maxImports } = limits;
 
     ruleRunner.testRule(ruleName, [
         {
@@ -68,35 +71,31 @@ function test(label, limits: { maxRules: number, maxSheets: number, maxImports: 
                 reports: [{ message: `Maximum of ${maxImports} nested imports reached (${maxImports})` }],
                 serverConfig: generateImports(maxImports)
             }
-            
-        //  exclude jsdom since it currently ignores @import rules
-        //  https://github.com/jsdom/jsdom/issues/2124
+
+        /*
+         * Exclude `jsdom` since it currently ignores `@import` rules.
+         * https://github.com/jsdom/jsdom/issues/2124
+         */
         ], { ...configs, ignoredConnectors: ['jsdom'] });
     }
-}
-
-test('', {
-    maxRules: 65534,
-    maxSheets: 4095,
-    maxImports: 0
-}, {
-    serial: true, //  keeps the tests from timing out due to the large numbers being checked
-});
-
-test(' targeting IE9', {
-    maxRules: 4095,
-    maxSheets: 31,
-    maxImports: 4
-}, {
-    browserslist: ['IE 9']
-});
-
-const customLimits = {
-    maxRules: 10,
-    maxSheets: 4,
-    maxImports: 2
 };
 
-test(' with custom limits', customLimits, {
-    ruleOptions: customLimits
-});
+test('', {
+    maxImports: 0,
+    maxRules: 65534,
+    maxSheets: 4095
+}, { serial: true }); // Keeps the tests from timing out due to the large numbers being checked.
+
+test(' targeting IE9', {
+    maxImports: 4,
+    maxRules: 4095,
+    maxSheets: 31
+}, { browserslist: ['IE 9'] });
+
+const customLimits = {
+    maxImports: 2,
+    maxRules: 10,
+    maxSheets: 4
+};
+
+test(' with custom limits', customLimits, { ruleOptions: customLimits });

--- a/packages/rule-stylesheet-limits/tests/tests.ts
+++ b/packages/rule-stylesheet-limits/tests/tests.ts
@@ -1,0 +1,64 @@
+import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
+import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
+import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
+
+const ruleName = 'stylesheet-limits';
+
+const generateCSSRules = (count = 1) => {
+    let rules = [];
+    for (let i = 1; i <= count; i++) {
+        rules.push(`.r${i}`);
+    }
+    return rules.join(',') + ' { color: #fff }';
+};
+
+/*
+ * You should test for cases where the rule passes and doesn't.
+ * More information about how `ruleRunner` can be configured is
+ * available in:
+ * https://sonarwhal.com/docs/contributor-guide/rules/#howtotestarule
+ */
+const maxRules = 65534;
+ruleRunner.testRule(ruleName, [
+    {
+        name: `Page contains less than ${maxRules} CSS rules`,
+        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRules - 1)}</style>`)
+    },
+    {
+        name: `Page contains ${maxRules} CSS rules`,
+        reports: [{ message: `Maximum of ${maxRules} CSS rules reached (${maxRules})` }],
+        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRules)}</style>`)
+    }
+]);
+
+const maxRulesIE9 = 4095;
+ruleRunner.testRule(ruleName, [
+    {
+        name: `Page targeting IE9 contains less than ${maxRulesIE9} CSS rules`,
+        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRulesIE9 - 1)}</style>`)
+    },
+    {
+        name: `Page targeting IE9 contains ${maxRulesIE9} CSS rules`,
+        reports: [{ message: `Maximum of ${maxRulesIE9} CSS rules reached (${maxRulesIE9})` }],
+        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRulesIE9)}</style>`)
+    }
+], {
+    browserslist: ['IE 9']
+});
+
+const maxRulesCustom = 10;
+ruleRunner.testRule(ruleName, [
+    {
+        name: `Page contains less than the customized ${maxRulesCustom} CSS rules`,
+        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRulesCustom - 1)}</style>`)
+    },
+    {
+        name: `Page contains the customized ${maxRulesCustom} CSS rules`,
+        reports: [{ message: `Maximum of ${maxRulesCustom} CSS rules reached (${maxRulesCustom})` }],
+        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRulesCustom)}</style>`)
+    }
+], {
+    ruleOptions: { 
+        'max-css-rules': 10
+    }
+});

--- a/packages/rule-stylesheet-limits/tests/tests.ts
+++ b/packages/rule-stylesheet-limits/tests/tests.ts
@@ -81,12 +81,6 @@ const test = (label, limits: { maxRules: number, maxSheets: number, maxImports: 
     }
 };
 
-test('', {
-    maxImports: 0,
-    maxRules: 65534,
-    maxSheets: 4095
-}, { serial: true }); // Keeps the tests from timing out due to the large numbers being checked.
-
 test(' targeting IE9', {
     maxImports: 4,
     maxRules: 4095,

--- a/packages/rule-stylesheet-limits/tests/tests.ts
+++ b/packages/rule-stylesheet-limits/tests/tests.ts
@@ -12,53 +12,91 @@ const generateCSSRules = (count = 1) => {
     return rules.join(',') + ' { color: #fff }';
 };
 
-/*
- * You should test for cases where the rule passes and doesn't.
- * More information about how `ruleRunner` can be configured is
- * available in:
- * https://sonarwhal.com/docs/contributor-guide/rules/#howtotestarule
- */
-const maxRules = 65534;
-ruleRunner.testRule(ruleName, [
-    {
-        name: `Page contains less than ${maxRules} CSS rules`,
-        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRules - 1)}</style>`)
-    },
-    {
-        name: `Page contains ${maxRules} CSS rules`,
-        reports: [{ message: `Maximum of ${maxRules} CSS rules reached (${maxRules})` }],
-        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRules)}</style>`)
+const generateStyleSheets = (count = 1) => {
+    let sheets = [];
+    for (let i = 1; i <= count; i++) {
+        sheets.push('<style>.r { color: #fff }</style>');
     }
-]);
+    return sheets.join('\n');
+};
 
-const maxRulesIE9 = 4095;
-ruleRunner.testRule(ruleName, [
-    {
-        name: `Page targeting IE9 contains less than ${maxRulesIE9} CSS rules`,
-        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRulesIE9 - 1)}</style>`)
-    },
-    {
-        name: `Page targeting IE9 contains ${maxRulesIE9} CSS rules`,
-        reports: [{ message: `Maximum of ${maxRulesIE9} CSS rules reached (${maxRulesIE9})` }],
-        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRulesIE9)}</style>`)
+const generateImports = (count = 1) => {
+    const config = {
+        '/': generateHTMLPage(`<style>@import url('i1.css');</style>`)
     }
-], {
+    for (let i = 1; i <= count; i++) {
+        config[`/i${i}.css`] = {
+            content: i < count ? `@import url('i${i + 1}.css');\n.r { color: #fff }` : '.r { color: #fff }',
+            headers: { 'Content-Type': 'text/css' }
+        }
+    }
+    return config;
+}
+
+function test(label, limits: { maxRules: number, maxSheets: number, maxImports: number }, configs: any) {
+    let { maxRules, maxSheets, maxImports } = limits;
+
+    ruleRunner.testRule(ruleName, [
+        {
+            name: `Page${label} contains less than ${maxRules} CSS rules`,
+            serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRules - 1)}</style>`)
+        },
+        {
+            name: `Page${label} contains ${maxRules} CSS rules`,
+            reports: [{ message: `Maximum of ${maxRules} CSS rules reached (${maxRules})` }],
+            serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRules)}</style>`)
+        },
+        {
+            name: `Page${label} contains less than ${maxSheets} stylesheets`,
+            serverConfig: generateHTMLPage(generateStyleSheets(maxSheets - 1))
+        },
+        {
+            name: `Page${label} contains ${maxSheets} stylesheets`,
+            reports: [{ message: `Maximum of ${maxSheets} stylesheets reached (${maxSheets})` }],
+            serverConfig: generateHTMLPage(generateStyleSheets(maxSheets))
+        }
+    ], configs);
+
+    if (maxImports) {
+        ruleRunner.testRule(ruleName, [
+            {
+                name: `Page${label} contains less than ${maxImports} nested imports`,
+                serverConfig: generateImports(maxImports - 1)
+            },
+            {
+                name: `Page${label} contains ${maxImports} nested imports`,
+                reports: [{ message: `Maximum of ${maxImports} nested imports reached (${maxImports})` }],
+                serverConfig: generateImports(maxImports)
+            }
+            
+        //  exclude jsdom since it currently ignores @import rules
+        //  https://github.com/jsdom/jsdom/issues/2124
+        ], { ...configs, ignoredConnectors: ['jsdom'] });
+    }
+}
+
+test('', {
+    maxRules: 65534,
+    maxSheets: 4095,
+    maxImports: 0
+}, {
+    serial: true, //  keeps the tests from timing out due to the large numbers being checked
+});
+
+test(' targeting IE9', {
+    maxRules: 4095,
+    maxSheets: 31,
+    maxImports: 4
+}, {
     browserslist: ['IE 9']
 });
 
-const maxRulesCustom = 10;
-ruleRunner.testRule(ruleName, [
-    {
-        name: `Page contains less than the customized ${maxRulesCustom} CSS rules`,
-        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRulesCustom - 1)}</style>`)
-    },
-    {
-        name: `Page contains the customized ${maxRulesCustom} CSS rules`,
-        reports: [{ message: `Maximum of ${maxRulesCustom} CSS rules reached (${maxRulesCustom})` }],
-        serverConfig: generateHTMLPage(`<style>${generateCSSRules(maxRulesCustom)}</style>`)
-    }
-], {
-    ruleOptions: { 
-        'max-css-rules': 10
-    }
+const customLimits = {
+    maxRules: 10,
+    maxSheets: 4,
+    maxImports: 2
+};
+
+test(' with custom limits', customLimits, {
+    ruleOptions: customLimits
 });

--- a/packages/rule-stylesheet-limits/tsconfig.json
+++ b/packages/rule-stylesheet-limits/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "exclude": [
+        "dist",
+        "node_modules"
+    ],
+    "extends": "../../tsconfig.json",
+    "include": [
+        "src/**/*.ts",
+        "tests/**/*.ts"
+    ]
+}

--- a/packages/rule-stylesheet-limits/tsconfig.json
+++ b/packages/rule-stylesheet-limits/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-        "outDir": "dist"
+        "outDir": "dist",
+        "strict": true
     },
     "exclude": [
         "dist",


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Fix #570 by adding checks for known stylesheet limits in IE9 (4095 rules, 31 stylesheets, and 4 nested imports) as well as the larger limits in IE10+ (65534 rules and 4095 stylesheets).

Currently nested import checks only trigger in the chrome connector due to a jsdom bug which ignores import rules. I disabled related tests for jsdom and left a comment so we can re-enable once the jsdom bug is fixed. All other checks trigger in both connectors.
