### PR TITLE
Add an example of what an immutable cache control header might look like

### DIFF
--- a/packages/rule-http-cache/src/rule.ts
+++ b/packages/rule-http-cache/src/rule.ts
@@ -381,7 +381,7 @@ export default class HttpCacheRule implements IRule {
 
             // We want long caches with "immutable" for static resources
             if (usedDirectives.has('no-cache') || !(longCache && immutable)) {
-                const message: string = `Static resources should have a long cache value (${maxAgeResource}) and use the immutable directive:\n${header}`;
+                const message: string = `Static resources should have a long cache value (${maxAgeResource}) and use the immutable directive:\n${header}\nExample: "cache-control: public,max-age=31536000,immutable"`;
 
                 await context.report(resource, element, message);
 


### PR DESCRIPTION
Docs: Add example of immutable cache header to error message

When seeing the below error message about far future expiring cache headers, it's not very actionable. Add an example of how to fix the error

![image](https://user-images.githubusercontent.com/331790/40854626-54778604-65d2-11e8-93ae-e378a7a613f4.png)
