### PR TITLE
Fix: Drop `mime-db` dependency for `http-compression` rule

### DIFF
--- a/packages/rule-http-compression/package.json
+++ b/packages/rule-http-compression/package.json
@@ -7,8 +7,7 @@
     "timeout": "1m"
   },
   "dependencies": {
-    "brotli": "^1.3.2",
-    "mime-db": "^1.34.0"
+    "brotli": "^1.3.2"
   },
   "description": "sonarwhal rule that checks for HTTP compression related best practices",
   "devDependencies": {

--- a/packages/rule-http-compression/src/rule.ts
+++ b/packages/rule-http-compression/src/rule.ts
@@ -8,7 +8,6 @@
  * ------------------------------------------------------------------------------
  */
 import * as decompressBrotli from 'brotli/decompress';
-import * as mimeDB from 'mime-db';
 
 import { Category } from 'sonarwhal/dist/src/lib/enums/category';
 import { RuleScope } from 'sonarwhal/dist/src/lib/enums/rulescope';
@@ -573,30 +572,24 @@ export default class HttpCompressionRule implements IRule {
         };
 
         const isCompressibleAccordingToMediaType = (mediaType: string): boolean => {
-            const COMMON_MEDIA_TYPES_THAT_SHOULD_BE_COMPRESSED = [
-                'image/x-icon',
-                'image/bmp'
-            ];
-
-            const COMMON_MEDIA_TYPES_THAT_SHOULD_NOT_BE_COMPRESSED = [
-                'image/jpeg',
-                'image/png',
-                'image/gif',
-                'font/woff2',
-                'font/woff',
-                'font/otf',
-                'font/ttf'
-            ];
 
             if (!mediaType) {
                 return false;
             }
 
-            /*
-             * The reason for doing the following is because
-             * `mime-db` is quite big, so querying it for
-             * eveything is expensive.
-             */
+            const OTHER_COMMON_MEDIA_TYPES_THAT_SHOULD_BE_COMPRESSED = [
+                'application/rtf',
+                'application/wasm',
+                'font/collection',
+                'font/eot',
+                'font/otf',
+                'font/sfnt',
+                'font/ttf',
+                'image/bmp',
+                'image/x-icon',
+                'x-shader/x-fragment',
+                'x-shader/x-vertex'
+            ];
 
             /*
              * Check if the media type is one of the common
@@ -605,29 +598,11 @@ export default class HttpCompressionRule implements IRule {
              */
 
             if (isTextMediaType(mediaType) ||
-                COMMON_MEDIA_TYPES_THAT_SHOULD_BE_COMPRESSED.includes(mediaType)) {
+                OTHER_COMMON_MEDIA_TYPES_THAT_SHOULD_BE_COMPRESSED.includes(mediaType)) {
                 return true;
             }
 
-            /*
-             * Check if the media type is one of the common
-             * ones for which it is known the response should
-             * not be compressed.
-             */
-
-            if (COMMON_MEDIA_TYPES_THAT_SHOULD_NOT_BE_COMPRESSED.includes(mediaType)) {
-                return false;
-            }
-
-            /*
-             * If the media type is not included in any of the
-             * above, check `mime-db`.
-             */
-
-            const typeInfo = mimeDB[mediaType];
-
-            return typeInfo && typeInfo.compressible;
-
+            return false;
         };
 
         const isSpecialCase = async (resource: string, element: IAsyncHTMLElement, response: Response): Promise<boolean> => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

`mime-db` was used as a source to check if something should be compressed, but the project is planning to drop the `compressible` data in the near future in favor of the [`compressible` project](https://github.com/jshttp/compressible).

All of the cases currently covered by `compressible` are already covered by our code, so this change just adds the cases that were covered by `mime-db` and not by our code, hence, maintaining backwards compatibility.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix: #1108
