### PR TITLE
New: Use path to load resources in `.sonarwhalrc`

### DIFF
--- a/packages/rule-amp-validator/tests/tests.ts
+++ b/packages/rule-amp-validator/tests/tests.ts
@@ -2,10 +2,10 @@
 
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import { readFile } from 'sonarwhal/dist/src/lib/utils/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const validAMPHTML = readFile(`${__dirname}/fixtures/valid-amp.html`);
 const invalidAMPHTML = readFile(`${__dirname}/fixtures/invalid-amp.html`);

--- a/packages/rule-apple-touch-icons/tests/tests.ts
+++ b/packages/rule-apple-touch-icons/tests/tests.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs';
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const defaultImage = fs.readFileSync(`${__dirname}/fixtures/apple-touch-icon.png`); // eslint-disable-line no-sync
 const imageWithIncorrectDimensions = fs.readFileSync(`${__dirname}/fixtures/incorrect-dimensions.png`); // eslint-disable-line no-sync

--- a/packages/rule-axe/tests/tests.ts
+++ b/packages/rule-axe/tests/tests.ts
@@ -2,10 +2,10 @@
 
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const html = {
     noProblems: generateHTMLPage(undefined, '<div role="main"><h1>test</h1></div>'),

--- a/packages/rule-babel-config/tests/is-valid.ts
+++ b/packages/rule-babel-config/tests/is-valid.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
-const ruleName = 'babel-config/is-valid';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-content-type/tests/tests.ts
+++ b/packages/rule-content-type/tests/tests.ts
@@ -3,11 +3,11 @@
 import * as fs from 'fs';
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const pngFileContent = fs.readFileSync(`${__dirname}/fixtures/image.png`); // eslint-disable-line no-sync
 const svgFileContent = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M1,1"/></svg>';

--- a/packages/rule-disown-opener/tests/tests.ts
+++ b/packages/rule-disown-opener/tests/tests.ts
@@ -2,11 +2,11 @@
 
 import { cutString } from 'sonarwhal/dist/src/lib/utils/misc';
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const generateMissingMessage = (value: string, linkTypes: Array<string>): string => {
     return `'${cutString(value, 100)}' is missing 'rel' ${linkTypes.length === 1 ? 'value' : 'values'} '${linkTypes.join('\', \'')}'`;

--- a/packages/rule-highest-available-document-mode/tests/tests.ts
+++ b/packages/rule-highest-available-document-mode/tests/tests.ts
@@ -1,11 +1,11 @@
 /* eslint sort-keys: 0, no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const metaTag = '<meta http-equiv="x-ua-compatible" content="ie=edge">';
 

--- a/packages/rule-html-checker/tests/tests.ts
+++ b/packages/rule-html-checker/tests/tests.ts
@@ -4,10 +4,10 @@ import * as mock from 'mock-require';
 
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { delay } from 'sonarwhal/dist/src/lib/utils/misc';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 const exampleUrl = 'https://empty.sonarwhal.com/';
 const validatorError = 'error';
 const defaultValidator = 'https://validator.w3.org/nu/';

--- a/packages/rule-http-cache/tests/tests.ts
+++ b/packages/rule-http-cache/tests/tests.ts
@@ -1,9 +1,9 @@
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const defaultTests: Array<RuleTest> = [
     {

--- a/packages/rule-http-compression/tests/tests-http.ts
+++ b/packages/rule-http-compression/tests/tests-http.ts
@@ -1,4 +1,4 @@
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
 import {
@@ -14,7 +14,7 @@ import {
     testsForUserConfigs
 } from './_tests';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 /*
  * TODO: Remove `ignoredConnectors` part once headless

--- a/packages/rule-http-compression/tests/tests-https.ts
+++ b/packages/rule-http-compression/tests/tests-https.ts
@@ -1,4 +1,4 @@
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
 import {
@@ -16,7 +16,7 @@ import {
     testsForUserConfigs
 } from './_tests';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 /*
  * TODO: Remove `ignoredConnectors` part once headless

--- a/packages/rule-https-only/tests/tests-https.ts
+++ b/packages/rule-https-only/tests/tests-https.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from 'fs';
 
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const png = readFileSync(`${__dirname}/fixtures/nellie-studying.png`);
 

--- a/packages/rule-https-only/tests/tests.ts
+++ b/packages/rule-https-only/tests/tests.ts
@@ -1,9 +1,9 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const testsNoHTTPS: Array<RuleTest> = [
     {

--- a/packages/rule-image-optimization-cloudinary/tests/tests.ts
+++ b/packages/rule-image-optimization-cloudinary/tests/tests.ts
@@ -3,11 +3,11 @@ import { readFileSync } from 'fs';
 import * as mock from 'mock-require';
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 const svg = readFileSync(`${__dirname}/fixtures/space-nellie.svg`);
 const png = readFileSync(`${__dirname}/fixtures/nellie-studying.png`);
 const invalid = readFileSync(`${__dirname}/fixtures/invalid-image.js`);

--- a/packages/rule-manifest-app-name/tests/tests.ts
+++ b/packages/rule-manifest-app-name/tests/tests.ts
@@ -1,5 +1,5 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
@@ -62,4 +62,4 @@ const tests: Array<RuleTest> = [
     }
 ];
 
-ruleRunner.testRule(getRuleName(__dirname), tests, { parsers: ['manifest'] });
+ruleRunner.testRule(getRulePath(__filename), tests, { parsers: ['manifest'] });

--- a/packages/rule-manifest-exists/tests/tests.ts
+++ b/packages/rule-manifest-exists/tests/tests.ts
@@ -1,7 +1,7 @@
 /* eslint sort-keys: 0, no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
@@ -79,4 +79,4 @@ const tests: Array<RuleTest> = [
     }
 ];
 
-ruleRunner.testRule(getRuleName(__dirname), tests, { parsers: ['manifest'] });
+ruleRunner.testRule(getRulePath(__filename), tests, { parsers: ['manifest'] });

--- a/packages/rule-manifest-file-extension/tests/tests.ts
+++ b/packages/rule-manifest-file-extension/tests/tests.ts
@@ -1,7 +1,7 @@
 /* eslint sort-keys: 0, no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
@@ -34,4 +34,4 @@ const tests: Array<RuleTest> = [
     }
 ];
 
-ruleRunner.testRule(getRuleName(__dirname), tests, { parsers: ['manifest'] });
+ruleRunner.testRule(getRulePath(__filename), tests, { parsers: ['manifest'] });

--- a/packages/rule-manifest-is-valid/tests/tests.ts
+++ b/packages/rule-manifest-is-valid/tests/tests.ts
@@ -1,11 +1,11 @@
 /* eslint sort-keys: 0, no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const htmlWithManifestSpecified = generateHTMLPage('<link rel="manifest" href="site.webmanifest">');
 

--- a/packages/rule-meta-charset-utf-8/tests/tests.ts
+++ b/packages/rule-meta-charset-utf-8/tests/tests.ts
@@ -1,7 +1,7 @@
 /* eslint sort-keys: 0, no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
@@ -104,4 +104,4 @@ const tests: Array<RuleTest> = [
      */
 ];
 
-ruleRunner.testRule(getRuleName(__dirname), tests);
+ruleRunner.testRule(getRulePath(__filename), tests);

--- a/packages/rule-meta-theme-color/tests/tests.ts
+++ b/packages/rule-meta-theme-color/tests/tests.ts
@@ -1,9 +1,9 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const invalidColorValues = [
     'currentcolor',

--- a/packages/rule-meta-viewport/tests/tests.ts
+++ b/packages/rule-meta-viewport/tests/tests.ts
@@ -1,9 +1,9 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const generateMegaViewport = (content: string = 'WiDTh = deVicE-Width, IniTial-Scale= 1.0') => {
     return `<mEtA   NaMe="ViEwPort" cOnTenT="${content}">`;

--- a/packages/rule-minified-js/tests/minified-js.ts
+++ b/packages/rule-minified-js/tests/minified-js.ts
@@ -1,13 +1,13 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
 const generateScriptTag = (script) => {
     return `<script>${script}</script>`;
 };
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const expectedMessageFromRule = 'JavaScript content could be minified';
 const unminifiedJs= `

--- a/packages/rule-no-bom/tests/tests.ts
+++ b/packages/rule-no-bom/tests/tests.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 import * as mock from 'mock-require';
 
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
@@ -12,7 +12,7 @@ const asyncWrapper = require('sonarwhal/dist/src/lib/utils/async-wrapper');
 const originalAsyncTry = asyncWrapper.asyncTry;
 
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 const bom = fs.readFileSync(`${__dirname}/fixtures/bom.html`); // eslint-disable-line no-sync
 const noBom = fs.readFileSync(`${__dirname}/fixtures/no-bom.html`); // eslint-disable-line no-sync
 

--- a/packages/rule-no-broken-links/tests/no-broken-links.ts
+++ b/packages/rule-no-broken-links/tests/no-broken-links.ts
@@ -1,9 +1,9 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const bodyWithValidLinks = `<div>
 <a href='https://example.com/'>Example</a>

--- a/packages/rule-no-disallowed-headers/tests/tests.ts
+++ b/packages/rule-no-disallowed-headers/tests/tests.ts
@@ -1,11 +1,11 @@
 /* eslint no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const htmlPageWithScript = generateHTMLPage(undefined, '<script src="test.js"></script>');
 const htmlPageWithManifest = generateHTMLPage('<link rel="manifest" href="test.webmanifest">');

--- a/packages/rule-no-friendly-error-pages/tests/tests.ts
+++ b/packages/rule-no-friendly-error-pages/tests/tests.ts
@@ -1,11 +1,11 @@
 /* eslint sort-keys: 0, no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const htmlPageWithLessThan256bytes = generateHTMLPage(undefined,
     `&lt; 256 bytes

--- a/packages/rule-no-html-only-headers/tests/tests.ts
+++ b/packages/rule-no-html-only-headers/tests/tests.ts
@@ -1,11 +1,11 @@
 /* eslint sort-keys: 0, no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 const htmlPage = generateHTMLPage(undefined, '<script src="test.js"></script>');
 
 const generateMessage = (values: Array<string>): string => {

--- a/packages/rule-no-http-redirects/tests/tests.ts
+++ b/packages/rule-no-http-redirects/tests/tests.ts
@@ -1,9 +1,9 @@
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const tests: Array<RuleTest> = [
     {

--- a/packages/rule-no-p3p/tests/tests.ts
+++ b/packages/rule-no-p3p/tests/tests.ts
@@ -1,9 +1,9 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const message = 'P3P is deprecated and should not be used';
 

--- a/packages/rule-no-protocol-relative-urls/tests/tests.ts
+++ b/packages/rule-no-protocol-relative-urls/tests/tests.ts
@@ -1,7 +1,7 @@
 /* eslint sort-keys: 0, no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
@@ -72,4 +72,4 @@ const tests: Array<RuleTest> = [
     }
 ];
 
-ruleRunner.testRule(getRuleName(__dirname), tests);
+ruleRunner.testRule(getRulePath(__filename), tests);

--- a/packages/rule-no-vulnerable-javascript-libraries/tests/tests.ts
+++ b/packages/rule-no-vulnerable-javascript-libraries/tests/tests.ts
@@ -3,7 +3,7 @@
 import * as fs from 'fs';
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
@@ -62,6 +62,6 @@ const userMediumConfigTests: Array<RuleTest> = [
     }
 ];
 
-ruleRunner.testRule(getRuleName(__dirname), defaultTests);
-ruleRunner.testRule(getRuleName(__dirname), userHighConfigTests, { ruleOptions: { severity: 'high' } });
-ruleRunner.testRule(getRuleName(__dirname), userMediumConfigTests, { ruleOptions: { severity: 'medium' } });
+ruleRunner.testRule(getRulePath(__filename), defaultTests);
+ruleRunner.testRule(getRulePath(__filename), userHighConfigTests, { ruleOptions: { severity: 'high' } });
+ruleRunner.testRule(getRulePath(__filename), userMediumConfigTests, { ruleOptions: { severity: 'medium' } });

--- a/packages/rule-performance-budget/tests/tests-http.ts
+++ b/packages/rule-performance-budget/tests/tests-http.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from 'fs';
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const image = readFileSync(`${__dirname}/fixtures/image.png`);
 

--- a/packages/rule-performance-budget/tests/tests-https.ts
+++ b/packages/rule-performance-budget/tests/tests-https.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from 'fs';
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const image = readFileSync(`${__dirname}/fixtures/image.png`);
 

--- a/packages/rule-sri/tests/tests-http.ts
+++ b/packages/rule-sri/tests/tests-http.ts
@@ -1,10 +1,10 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { readFile } from 'sonarwhal/dist/src/lib/utils/misc';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const styles = readFile(`${__dirname}/fixtures/styles.css`);
 

--- a/packages/rule-sri/tests/tests-https.ts
+++ b/packages/rule-sri/tests/tests-https.ts
@@ -1,10 +1,10 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { readFile } from 'sonarwhal/dist/src/lib/utils/misc';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const styles = readFile(`${__dirname}/fixtures/styles.css`);
 const scripts = readFile(`${__dirname}/fixtures/scripts.js`);

--- a/packages/rule-ssllabs/tests/tests.ts
+++ b/packages/rule-ssllabs/tests/tests.ts
@@ -4,9 +4,9 @@ import * as mock from 'mock-require';
 
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const ssllabsMock = (response) => {
     const mockedModule = {

--- a/packages/rule-strict-transport-security/tests/http-tests.ts
+++ b/packages/rule-strict-transport-security/tests/http-tests.ts
@@ -1,11 +1,11 @@
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 
 import * as common from './_common';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const noHttpServerTests: Array<RuleTest> = [{
     name: `strict-transport-security sent over HTTP`,

--- a/packages/rule-strict-transport-security/tests/https-tests.ts
+++ b/packages/rule-strict-transport-security/tests/https-tests.ts
@@ -1,11 +1,11 @@
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 
 import * as common from './_common';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const defaultTests: Array<RuleTest> = [
     {

--- a/packages/rule-stylesheet-limits/tests/tests.ts
+++ b/packages/rule-stylesheet-limits/tests/tests.ts
@@ -1,8 +1,8 @@
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 const generateCSSRules = (count = 1) => {
     const rules = [];

--- a/packages/rule-typescript-config/tests/consistent-casing.ts
+++ b/packages/rule-typescript-config/tests/consistent-casing.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
-const ruleName = 'typescript-config/consistent-casing';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-typescript-config/tests/import-helpers.ts
+++ b/packages/rule-typescript-config/tests/import-helpers.ts
@@ -2,11 +2,12 @@ import * as path from 'path';
 
 import * as sinon from 'sinon';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as misc from 'sonarwhal/dist/src/lib/utils/misc';
 
-const ruleName = 'typescript-config/import-helpers';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-typescript-config/tests/is-valid.ts
+++ b/packages/rule-typescript-config/tests/is-valid.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
-const ruleName = 'typescript-config/is-valid';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-typescript-config/tests/no-comments.ts
+++ b/packages/rule-typescript-config/tests/no-comments.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
-const ruleName = 'typescript-config/no-comments';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {
@@ -13,8 +14,8 @@ const tests: Array<RuleLocalTest> = [
     {
         name: 'Configuration with "compilerOptions.removeComments = false" should fail',
         path: path.join(__dirname, 'fixtures', 'no-comments', 'invalid'),
-        reports: [{message: 'The compiler option "removeComments" should be enabled to reduce the output size.'}]
+        reports: [{ message: 'The compiler option "removeComments" should be enabled to reduce the output size.' }]
     }
 ];
 
-ruleRunner.testLocalRule(ruleName, tests, {parsers: ['typescript-config']});
+ruleRunner.testLocalRule(ruleName, tests, { parsers: ['typescript-config'] });

--- a/packages/rule-typescript-config/tests/strict.ts
+++ b/packages/rule-typescript-config/tests/strict.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
-const ruleName = 'typescript-config/strict';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-typescript-config/tests/target.ts
+++ b/packages/rule-typescript-config/tests/target.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
-const ruleName = 'typescript-config/target';
+const ruleName = getRulePath(__filename, true);
 
 type TestWithBrowserInfo = RuleLocalTest & {
     browserslist: Array<string>;

--- a/packages/rule-validate-set-cookie-header/tests/tests.ts
+++ b/packages/rule-validate-set-cookie-header/tests/tests.ts
@@ -2,9 +2,9 @@
 
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 
-const ruleName = getRuleName(__dirname);
+const ruleName = getRulePath(__filename);
 
 // Headers.
 const setCookie = (fields) => {

--- a/packages/rule-webpack-config/tests/config-exists.ts
+++ b/packages/rule-webpack-config/tests/config-exists.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
-const ruleName = 'webpack-config/config-exists';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-webpack-config/tests/is-installed.ts
+++ b/packages/rule-webpack-config/tests/is-installed.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as mock from 'mock-require';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
@@ -10,7 +11,7 @@ const webpackDestPath = path.join(__dirname, 'fixtures', 'valid', 'package.json'
 const webpackConfig = misc.loadJSONFile(webpackDestPath);
 const originalGetPackage = misc.getPackage;
 
-const ruleName = 'webpack-config/is-installed';
+const ruleName = getRulePath(__filename, true);
 const tests: Array<RuleLocalTest> = [
     {
         after() {

--- a/packages/rule-webpack-config/tests/is-valid.ts
+++ b/packages/rule-webpack-config/tests/is-valid.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
-const ruleName = 'webpack-config/is-valid';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-webpack-config/tests/module-esnext-typescript.ts
+++ b/packages/rule-webpack-config/tests/module-esnext-typescript.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as mock from 'mock-require';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
@@ -11,7 +12,7 @@ const webpackV1DestPath = path.join(__dirname, 'fixtures', 'version1', 'package.
 const webpackConfig = misc.loadJSONFile(webpackDestPath);
 const webpackV1Config = misc.loadJSONFile(webpackV1DestPath);
 const originalGetPackage = misc.getPackage;
-const ruleName = 'webpack-config/module-esnext-typescript';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-webpack-config/tests/modules-false-babel.ts
+++ b/packages/rule-webpack-config/tests/modules-false-babel.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as mock from 'mock-require';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
@@ -11,7 +12,7 @@ const webpackV1DestPath = path.join(__dirname, 'fixtures', 'version1', 'package.
 const webpackConfig = misc.loadJSONFile(webpackDestPath);
 const webpackV1Config = misc.loadJSONFile(webpackV1DestPath);
 const originalGetPackage = misc.getPackage;
-const ruleName = 'webpack-config/modules-false-babel';
+const ruleName = getRulePath(__filename, true);
 
 const tests: Array<RuleLocalTest> = [
     {

--- a/packages/rule-webpack-config/tests/no-devtool-in-prod.ts
+++ b/packages/rule-webpack-config/tests/no-devtool-in-prod.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as mock from 'mock-require';
 
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 import { RuleLocalTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 
@@ -10,7 +11,7 @@ const webpackDestPath = path.join(__dirname, 'fixtures', 'valid', 'package.json'
 const webpackConfig = misc.loadJSONFile(webpackDestPath);
 const originalGetPackage = misc.getPackage;
 
-const ruleName = 'webpack-config/no-devtool-in-prod';
+const ruleName = getRulePath(__filename, true);
 const tests: Array<RuleLocalTest> = [
     {
         after() {

--- a/packages/rule-x-content-type-options/tests/tests.ts
+++ b/packages/rule-x-content-type-options/tests/tests.ts
@@ -1,7 +1,7 @@
 /* eslint no-undefined: 0 */
 
 import { generateHTMLPage } from 'sonarwhal/dist/tests/helpers/misc';
-import { getRuleName } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
+import { getRulePath } from 'sonarwhal/dist/src/lib/utils/rule-helpers';
 import { RuleTest } from 'sonarwhal/dist/tests/helpers/rule-test-type';
 import * as ruleRunner from 'sonarwhal/dist/tests/helpers/rule-runner';
 
@@ -60,4 +60,4 @@ const tests: Array<RuleTest> = [
     }
 ];
 
-ruleRunner.testRule(getRuleName(__dirname), tests);
+ruleRunner.testRule(getRulePath(__filename), tests);

--- a/packages/sonarwhal/src/lib/config.ts
+++ b/packages/sonarwhal/src/lib/config.ts
@@ -15,6 +15,7 @@
 
 import * as os from 'os';
 import * as path from 'path';
+import * as fs from 'fs';
 
 import * as browserslist from 'browserslist';
 import * as shell from 'shelljs';
@@ -236,7 +237,6 @@ export class SonarwhalConfig {
         return browserslist(config.browserslist);
     }
 
-
     /**
      * Loads a configuration file regardless of the source. Inspects the file path
      * to determine the correctly way to load the config file.
@@ -253,13 +253,85 @@ export class SonarwhalConfig {
                     config = loadJSONFile(filePath);
                 }
                 break;
-
             case '.js':
                 config = loadJSFile(filePath);
                 break;
 
             default:
                 config = null;
+        }
+
+        config = this.toAbsolutePaths(config, filePath);
+
+        return config;
+    }
+
+    /**
+     * Transforms any relative paths in the configuration to absolute using
+     * the value of `configPath`. `configPath` needs to be a folder.
+     * The values that can be changed are:
+     * * `connector`'s value: `{ "connector": "./myconnector" }`
+     * * `connector.name` value: `{ "connector": { "name": "./myconnector"} }`
+     * * `formatter`s and `parser`s  values: `{ "formatters": ["./myformatter"] }`
+     * * `rule`s keys: `{ "rules: { "./myrule": "warning" } }`
+     */
+    public static toAbsolutePaths(config: UserConfig, configRoot: string): UserConfig {
+        if (!config) {
+            return null;
+        }
+
+        const stat = fs.statSync(configRoot); //eslint-disable-line
+        const configPath = stat.isDirectory() ? configRoot : path.dirname(configRoot);
+
+        if (!configPath) {
+            return config;
+        }
+
+        const resolve = (value: string): string => {
+            if (!value.startsWith('.')) {
+                return value;
+            }
+
+            return path.resolve(configPath, value);
+        };
+
+        // Update the connector value
+        if (config.connector) {
+            if (typeof config.connector === 'string') {
+                config.connector = resolve(config.connector);
+            } else {
+                config.connector.name = resolve(config.connector.name);
+            }
+        }
+
+        // Update extends
+        if (config.extends) {
+            config.extends = config.extends.map(resolve);
+        }
+
+        // Update formatters
+        if (config.formatters) {
+            config.formatters = config.formatters.map(resolve);
+        }
+
+        // Update parsers
+        if (config.parsers) {
+            config.parsers = config.parsers.map(resolve);
+        }
+
+        // Update rules
+        if (config.rules) {
+            const rules = Object.keys(config.rules);
+
+            const transformedRules = rules.reduce((newRules, currentRule) => {
+                const newRule = resolve(currentRule);
+
+                newRules[newRule] = config.rules[currentRule];
+
+                return newRules;
+            }, {});
+
+            config.rules = transformedRules;
         }
 
         return config;
@@ -275,7 +347,6 @@ export class SonarwhalConfig {
             throw new Error(`Couldn't find any valid configuration`);
         }
 
-        // 3, 4
         const userConfig = composeConfig(config);
 
         if (typeof userConfig.connector === 'string') {

--- a/packages/sonarwhal/src/lib/config/config-default.json
+++ b/packages/sonarwhal/src/lib/config/config-default.json
@@ -1,4 +1,0 @@
-{
-    "connector": "jsdom",
-    "formatter": "json"
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,7 +813,7 @@ babel-core@^6.17.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-generator@^6.1.0, babel-generator@^6.26.0:
+babel-generator@^6.1.0, babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
   dependencies:
@@ -1038,7 +1038,7 @@ babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -1048,7 +1048,7 @@ babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -1062,7 +1062,7 @@ babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.18.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -3910,6 +3910,18 @@ istanbul-lib-hook@^1.1.0:
   dependencies:
     append-transform "^0.4.0"
 
+istanbul-lib-instrument@^1.10.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.2.0"
+    semver "^5.3.0"
+
 istanbul-lib-instrument@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-2.2.0.tgz#08091ae49d0b330be2a839dc25c250324c4bedaa"
@@ -3931,6 +3943,16 @@ istanbul-lib-report@^1.1.3:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
+istanbul-lib-source-maps@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.1.2"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
 istanbul-lib-source-maps@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
@@ -3941,7 +3963,7 @@ istanbul-lib-source-maps@^1.2.5:
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.4.1:
+istanbul-reports@^1.4.0, istanbul-reports@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.5.0.tgz#c6c2867fa65f59eb7dcedb7f845dfc76aaee70f9"
   dependencies:
@@ -4527,9 +4549,28 @@ markdownlint-cli@^0.10.0:
     markdownlint "~0.10.0"
     rc "~1.2.7"
 
+markdownlint-cli@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli/-/markdownlint-cli-0.9.0.tgz#241a62e98ba5fd1594f57adb5823bc6bf83e95e2"
+  dependencies:
+    commander "~2.9.0"
+    deep-extend "~0.5.1"
+    get-stdin "~5.0.1"
+    glob "~7.0.3"
+    lodash.differencewith "~4.5.0"
+    lodash.flatten "~4.4.0"
+    markdownlint "~0.9.0"
+    rc "~1.2.7"
+
 markdownlint@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.10.0.tgz#ee941ee943f78ff6adbc1ff0fad49365e600b664"
+  dependencies:
+    markdown-it "8.4.1"
+
+markdownlint@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.9.0.tgz#f2500856b6c2a1450b919dcb4671d4116fb1f0bf"
   dependencies:
     markdown-it "8.4.1"
 
@@ -5046,6 +5087,38 @@ number-is-nan@^1.0.0:
 nwsapi@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.2.tgz#33a0aab27c678d4dfdbba6a7f84b1c627fc4966f"
+
+nyc@^11.8.0:
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.9.0.tgz#4106e89e8fbe73623a1fc8b6ecb7abaa271ae1e4"
+  dependencies:
+    archy "^1.0.0"
+    arrify "^1.0.1"
+    caching-transform "^1.0.0"
+    convert-source-map "^1.5.1"
+    debug-log "^1.0.1"
+    default-require-extensions "^1.0.0"
+    find-cache-dir "^0.1.1"
+    find-up "^2.1.0"
+    foreground-child "^1.5.3"
+    glob "^7.0.6"
+    istanbul-lib-coverage "^1.1.2"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^1.10.0"
+    istanbul-lib-report "^1.1.3"
+    istanbul-lib-source-maps "^1.2.3"
+    istanbul-reports "^1.4.0"
+    md5-hex "^1.2.0"
+    merge-source-map "^1.1.0"
+    micromatch "^3.1.10"
+    mkdirp "^0.5.0"
+    resolve-from "^2.0.0"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.1"
+    spawn-wrap "^1.4.2"
+    test-exclude "^4.2.0"
+    yargs "11.1.0"
+    yargs-parser "^8.0.0"
 
 nyc@^12.0.2:
   version "12.0.2"
@@ -6938,6 +7011,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript-eslint-parser@^15.0.0:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-15.0.1.tgz#fb18bfd255821c5c1dcb98be826f7e4fac63480c"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
+
 typescript-eslint-parser@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-16.0.0.tgz#14a9ab75932b15af919602faef553c6f0487f352"
@@ -6949,7 +7029,7 @@ typescript@^2.8.1:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
-typescript@^2.9.2:
+typescript@^2.8.3, typescript@^2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 


### PR DESCRIPTION
Enable loading a resource using a path instead of the ID of the package.
This is useful when you have multiple configuration files with some
common parts or when you have a locally developed rule that you don't
want to publish on a package.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #1123

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
