### PR TITLE
Fix: Add missing `#!` in `create-` packages

### DIFF
--- a/packages/create-hint/webpack.config.js
+++ b/packages/create-hint/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = () => {
         output: { filename: 'src/[name].js' },
         plugins: [
             new webpack.ProgressPlugin(),
-            new ForkTsCheckerWebpackPlugin()
+            new ForkTsCheckerWebpackPlugin(),
+            new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true })
         ],
         resolve: {
             alias: { handlebars: 'handlebars/dist/handlebars.min.js' },

--- a/packages/create-parser/webpack.config.js
+++ b/packages/create-parser/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = () => {
         output: { filename: 'src/[name].js' },
         plugins: [
             new webpack.ProgressPlugin(),
-            new ForkTsCheckerWebpackPlugin()
+            new ForkTsCheckerWebpackPlugin(),
+            new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true })
         ],
         resolve: {
             alias: { handlebars: 'handlebars/dist/handlebars.min.js' },


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x]  Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Add `#!/usr/bin/env node` to the output generated by webpack in the `create-*` packages.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
