### PR TITLE
Fix: Issue locating `package.json` with initializers

### DIFF
--- a/packages/create-hint/package.json
+++ b/packages/create-hint/package.json
@@ -7,25 +7,23 @@
     "timeout": "1m"
   },
   "bin": {
-    "create-hint": "dist/src/new-hint.js"
-  },
-  "dependencies": {
-    "fs-extra": "^6.0.1",
-    "handlebars": "^4.0.11",
-    "inquirer": "^6.0.0",
-    "mkdirp": "^0.5.1",
-    "hint": "^1.0.0"
+    "create-hint": "./dist/src/new-hint.js"
   },
   "description": "webhint's hint initializer package",
   "devDependencies": {
     "ava": "^0.25.0",
     "cpx": "^1.5.0",
+    "hint": "^1.0.0",
     "eslint": "^5.0.1",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-markdown": "^1.0.0-beta.7",
     "eslint-plugin-typescript": "^0.12.0",
     "fork-ts-checker-webpack-plugin": "^0.4.2",
+    "fs-extra": "^6.0.1",
+    "handlebars": "^4.0.11",
+    "inquirer": "^6.0.0",
     "markdownlint-cli": "^0.10.0",
+    "mkdirp": "^0.5.1",
     "npm-link-check": "^2.0.0",
     "npm-run-all": "^4.1.2",
     "nyc": "^12.0.2",

--- a/packages/create-hint/webpack.config.js
+++ b/packages/create-hint/webpack.config.js
@@ -24,9 +24,11 @@ module.exports = () => {
         },
         output: { filename: 'src/[name].js' },
         plugins: [
-            new webpack.ProgressPlugin(),
             new ForkTsCheckerWebpackPlugin(),
-            new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true })
+            new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true }),
+            // We set process.env.webpack becase there are different code paths if we are bundling around loading resources
+            new webpack.DefinePlugin({ 'process.env.webpack': JSON.stringify(true) }),
+            new webpack.ProgressPlugin()
         ],
         resolve: {
             alias: { handlebars: 'handlebars/dist/handlebars.min.js' },

--- a/packages/create-parser/package.json
+++ b/packages/create-parser/package.json
@@ -7,14 +7,7 @@
     "timeout": "1m"
   },
   "bin": {
-    "create-parser": "dist/src/new-parser.js"
-  },
-  "dependencies": {
-    "fs-extra": "^6.0.1",
-    "handlebars": "^4.0.11",
-    "inquirer": "^6.0.0",
-    "mkdirp": "^0.5.1",
-    "hint": "^1.0.0"
+    "create-parser": "./dist/src/new-parser.js"
   },
   "description": "webhint's parser initializer package",
   "devDependencies": {
@@ -25,7 +18,12 @@
     "eslint-plugin-markdown": "^1.0.0-beta.7",
     "eslint-plugin-typescript": "^0.12.0",
     "fork-ts-checker-webpack-plugin": "^0.4.2",
+    "fs-extra": "^6.0.1",
+    "handlebars": "^4.0.11",
+    "inquirer": "^6.0.0",
+    "hint": "^1.0.0",
     "markdownlint-cli": "^0.10.0",
+    "mkdirp": "^0.5.1",
     "npm-link-check": "^2.0.0",
     "npm-run-all": "^4.1.2",
     "nyc": "^12.0.2",

--- a/packages/create-parser/webpack.config.js
+++ b/packages/create-parser/webpack.config.js
@@ -24,9 +24,11 @@ module.exports = () => {
         },
         output: { filename: 'src/[name].js' },
         plugins: [
-            new webpack.ProgressPlugin(),
             new ForkTsCheckerWebpackPlugin(),
-            new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true })
+            new webpack.BannerPlugin({ banner: '#!/usr/bin/env node', raw: true }),
+            // We set process.env.webpack becase there are different code paths if we are bundling around loading resources
+            new webpack.DefinePlugin({ 'process.env.webpack': JSON.stringify(true) }),
+            new webpack.ProgressPlugin()
         ],
         resolve: {
             alias: { handlebars: 'handlebars/dist/handlebars.min.js' },

--- a/packages/hint/src/lib/utils/packages/load-hint-package.ts
+++ b/packages/hint/src/lib/utils/packages/load-hint-package.ts
@@ -1,10 +1,13 @@
 import findPackageRoot from './find-package-root';
 
-
 /** Returns an object that represents the `package.json` version of `hint` */
 export default () => {
-    const pkgPath = findPackageRoot();
-    const pkg = require(`${pkgPath}/package.json`);
+    // webpack will embed the package.json
+    if (process.env.webpack) { // eslint-disable-line no-process-env
+        return require('../../../../../package.json');
+    }
 
-    return pkg;
+    const pkgPath = findPackageRoot();
+
+    return require(`${pkgPath}/package.json`);
 };


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

This adds a `process.env.webpack` variable to change some of the code
paths when webpack is used to bundle.

In this particular case is for `loadHintPackage`.

It also moves the `dependencies` to `devDependecies` so they aren't published when we bundle the package.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
